### PR TITLE
COC rental field

### DIFF
--- a/src/webapp/src/lt/Entry.ts
+++ b/src/webapp/src/lt/Entry.ts
@@ -64,7 +64,7 @@ export class LtEntry {
     ) {
         this.StartNo = null;
         this.Epunch = entry.EPunch
-        this.EpunchRented= (entry.EPunch === '' && entry.Group !== '*') ? true:false;
+        this.EpunchRented= (entry.Rental === 'X' && entry.Group !== '*') ? true:(entry.EPunch === '' && entry.Group !== '*') ? true:false;
         this.FirstName= entry.FirstName
         this.LastName= entry.LastName
         this.Club= entry.Club

--- a/src/webapp/src/orienteering/CascadeRegistration.ts
+++ b/src/webapp/src/orienteering/CascadeRegistration.ts
@@ -17,6 +17,7 @@ export class CascadeRegistrationCsv {
     Paid!: string;
     Owed!: number | null;
     Waiver!: string;
+    Rental?: string | null;
 }
 
 export function isCascadeRegistrationCsv(row:any): boolean | "group" {


### PR DESCRIPTION
Allow addition of a "Rental" column in the COC reg file - if an X is present in that column (and this isn't a group member), then mark the row as a rental epunch. Otherwise use the old epunch logic just looking for blank epunch column.