### PR TITLE
ScoreO results - refactors all race data import

### DIFF
--- a/losttime.web/src/results2/CompetitionClass/CompetitionClass.ts
+++ b/losttime.web/src/results2/CompetitionClass/CompetitionClass.ts
@@ -1,8 +1,9 @@
 import { Guid } from "guid-typescript";
 import { ComputedCompetitionClass } from "../ComputedCompetitionClass/ComputedCompetitionClass";
-import { PersonResult } from "../../shared/orienteeringtypes/IofResultXml";
 import { StandardRaceClassData } from "../StandardRaceClassData";
 import { CompetitionClassType, Results2ScoreMethod } from "../CompetitionClassType";
+import { LtResult } from "../../shared/orienteeringtypes/LtResult";
+import { LtScoreOResult } from "../../shared/orienteeringtypes/LtScoreOResult";
 
 export abstract class CompetitionClass {
     id: Guid;
@@ -26,11 +27,11 @@ export abstract class CompetitionClass {
     // helpers for process actions go here
     // but ONLY if they are relevant to all Result types
 
-    contributingResultsFlat(): PersonResult[] {
-        let results: PersonResult[] = []
+    contributingResultsFlat(): (LtResult|LtScoreOResult)[] {
+        let results:(LtResult|LtScoreOResult)[] = []
         for (const race of this.contributingResults) {
-            if (race.xmlPersonResults.length === undefined) {continue;}
-            results.push(...race.xmlPersonResults);
+            if (race.results.length === undefined) {continue;}
+            results.push(...race.results)
         }
         return results
     }
@@ -38,7 +39,7 @@ export abstract class CompetitionClass {
     contributingNames(): {race:string, class:string}[] {
         let names:{race:string, class:string}[] = []
         this.contributingResults.forEach(raceClass => {
-            names.push({race:raceClass.race_name, class:raceClass.xmlClass.Name})
+            names.push({race:raceClass.race_name, class:raceClass.class.name})
         });
         return names;
     }

--- a/losttime.web/src/results2/CompetitionClass/SingleRaceSoloPointedResult.ts
+++ b/losttime.web/src/results2/CompetitionClass/SingleRaceSoloPointedResult.ts
@@ -1,6 +1,0 @@
-import { SingleRaceSoloResult } from "./SingleRaceSoloResult";
-
-export class SingleRaceSoloPointedResult extends SingleRaceSoloResult {
-    points: number | null | undefined;
-
-}

--- a/losttime.web/src/results2/CompetitionClass/SingleRaceSoloScoreOResult.ts
+++ b/losttime.web/src/results2/CompetitionClass/SingleRaceSoloScoreOResult.ts
@@ -1,0 +1,22 @@
+import { LtScoreOResult } from "../../shared/orienteeringtypes/LtScoreOResult";
+import { SingleRaceSoloResult } from "./SingleRaceSoloResult";
+
+export class SingleRaceSoloScoreOResult extends SingleRaceSoloResult {
+    scoreRaw: number;
+    penalty: number; // always positive
+    bonus: number;
+    score: number // pointsRaw - penalty + bonus = score
+
+    constructor(ltResult:LtScoreOResult) {
+        super(ltResult)
+        this.scoreRaw = ltResult.scoreRaw
+        this.penalty = ltResult.penalty
+        this.bonus = ltResult.bonus
+        this.score = ltResult.score
+    }
+
+    static getRawScore = (r:SingleRaceSoloScoreOResult):string => `${r.scoreRaw}`
+    static getPenalty = (r:SingleRaceSoloScoreOResult):string => `${r.penalty?? ""}`
+    static getFinalScore = (r:SingleRaceSoloScoreOResult):string => `${r.score}`
+
+}

--- a/losttime.web/src/results2/CompetitionClass/SingleRaceTeamResult.ts
+++ b/losttime.web/src/results2/CompetitionClass/SingleRaceTeamResult.ts
@@ -7,7 +7,6 @@ export class SingleRaceTeamResult {
     soloResults: SingleRaceSoloResult[]
     place: number | null | undefined
     points: number | null | undefined
-    isValid: boolean
 
     constructor(results:SingleRaceSoloResult[], name:string, club?:string, ) {
         this.teamName = name;
@@ -15,7 +14,6 @@ export class SingleRaceTeamResult {
         this.soloResultsAll = results
 
         this.soloResults = []
-        this.isValid = false
     }
 
     static getPoints = (r:SingleRaceTeamResult):string =>`${r.place ?? ""}`

--- a/losttime.web/src/results2/CompetitionClass/SingleRaceTeamResult.ts
+++ b/losttime.web/src/results2/CompetitionClass/SingleRaceTeamResult.ts
@@ -1,15 +1,15 @@
-import { SingleRaceSoloPointedResult } from "./SingleRaceSoloPointedResult"
+import { SingleRaceSoloResult } from "./SingleRaceSoloResult"
 
 export class SingleRaceTeamResult {
     teamName: string
     club?: string
-    soloResultsAll: SingleRaceSoloPointedResult[]
-    soloResults: SingleRaceSoloPointedResult[]
+    soloResultsAll: SingleRaceSoloResult[]
+    soloResults: SingleRaceSoloResult[]
     place: number | null | undefined
     points: number | null | undefined
     isValid: boolean
 
-    constructor(results:SingleRaceSoloPointedResult[], name:string, club?:string, ) {
+    constructor(results:SingleRaceSoloResult[], name:string, club?:string, ) {
         this.teamName = name;
         this.club = club;
         this.soloResultsAll = results
@@ -17,4 +17,7 @@ export class SingleRaceTeamResult {
         this.soloResults = []
         this.isValid = false
     }
+
+    static getPoints = (r:SingleRaceTeamResult):string =>`${r.place ?? ""}`
+    static getTeamClub = (r:SingleRaceTeamResult):string => `${r.teamName} (${r.club})`
 }

--- a/losttime.web/src/results2/CompetitionClass/Templates/CompetitionClassPresets_Cascade.ts
+++ b/losttime.web/src/results2/CompetitionClass/Templates/CompetitionClassPresets_Cascade.ts
@@ -5,6 +5,8 @@ import { raceClassesByRace } from "../../Components/Compose/CompetitionClassComp
 import { CompetitionClassPresetButton } from "./CompetitionClassPresetButton";
 import { Cascade_SingleSoloScottish1k } from "../Variants/Cascade_SingleSoloScottish1k";
 import { Cascade_SingleTeamWorldCup } from "../Variants/Cascade_SingleTeamWorldCup";
+import { Cascade_SingleSoloScoreOScottish1k } from "../Variants/Cascade_SingleSoloScoreOScottish1k";
+import { Standard_ScoreO } from "../Variants/Standard_ScoreO";
 
 type raceClassesByClass = Map<string, (StandardRaceClassData|undefined)[]>
 
@@ -98,6 +100,47 @@ function COC_UO25_Single(raceData:CompetitionClassPresetsProps) {
     ])
 }
 
+function COC_UO25_SingleScoreO(raceData:CompetitionClassPresetsProps) {
+    raceData.setCompetitionClasses([
+    new Standard_ScoreO('Beginner', getRaceDataByClassCode(raceData,"Beg",true)),
+    new Standard_ScoreO('Intermediate', getRaceDataByClassCode(raceData,"Int",true)),
+    new Standard_ScoreO('Short Advancecd', getRaceDataByClassCode(raceData,"Short Adv",true)),
+    new Standard_ScoreO('Long Advanced Rec / Groups', getRaceDataByClassCode(raceData,"Long AdvG",true)),
+    new Cascade_SingleSoloScoreOScottish1k('16 and Under Female', getRaceDataByClassCode(raceData,"16F",true)),
+    new Cascade_SingleSoloScoreOScottish1k('16 and Under Open', getRaceDataByClassCode(raceData,"16O",true)),
+    new Cascade_SingleSoloScoreOScottish1k('18 and Under Female', getRaceDataByClassCode(raceData,"18F",true)),
+    new Cascade_SingleSoloScoreOScottish1k('18 and Under Open', getRaceDataByClassCode(raceData,"18O",true)),
+    new Cascade_SingleSoloScoreOScottish1k('50+ Female', getRaceDataByClassCode(raceData,"50+F",true)),
+    new Cascade_SingleSoloScoreOScottish1k('50+ Open', getRaceDataByClassCode(raceData,"50+O",true)),
+    new Cascade_SingleSoloScoreOScottish1k('70+ Female', getRaceDataByClassCode(raceData,"70+F",true)),
+    new Cascade_SingleSoloScoreOScottish1k('70+ Open', getRaceDataByClassCode(raceData,"70+O",true)),
+    new Cascade_SingleSoloScoreOScottish1k('20 and Under Female', getRaceDataByClassCode(raceData,"20F",true)),
+    new Cascade_SingleSoloScoreOScottish1k('20 and Under Open', getRaceDataByClassCode(raceData,"20O",true)),
+    new Cascade_SingleSoloScoreOScottish1k('Open (-21+) Female', getRaceDataByClassCode(raceData,"21F",true)),
+    new Cascade_SingleSoloScoreOScottish1k('Open (-21+)', getRaceDataByClassCode(raceData,"21O",true))
+    ])
+}
+
+function COC_UO22_Single(raceData:CompetitionClassPresetsProps) {
+    raceData.setCompetitionClasses([
+    new Standard_ScoreO('Beginner', getRaceDataByClassCode(raceData,"1",true)),
+    new Standard_ScoreO('Intermediate', getRaceDataByClassCode(raceData,"2",true)),
+    new Standard_ScoreO('Open Groups', getRaceDataByClassCode(raceData,"3G",true)),
+    new Cascade_SingleSoloScoreOScottish1k('16 and Under Female', getRaceDataByClassCode(raceData,"UJ16F",true)),
+    new Cascade_SingleSoloScoreOScottish1k('16 and Under Open', getRaceDataByClassCode(raceData,"UJ16M",true)),
+    new Cascade_SingleSoloScoreOScottish1k('18 and Under Female', getRaceDataByClassCode(raceData,"UJ18F",true)),
+    new Cascade_SingleSoloScoreOScottish1k('18 and Under Open', getRaceDataByClassCode(raceData,"UJ18M",true)),
+    new Cascade_SingleSoloScoreOScottish1k('20 and Under Female', getRaceDataByClassCode(raceData,"UJ20F",true)),
+    new Cascade_SingleSoloScoreOScottish1k('20 and Under Open', getRaceDataByClassCode(raceData,"UJ20M",true)),
+    new Cascade_SingleSoloScoreOScottish1k('50+ Female', getRaceDataByClassCode(raceData,"UM50F",true)),
+    new Cascade_SingleSoloScoreOScottish1k('50+ Open', getRaceDataByClassCode(raceData,"UM50M",true)),
+    new Cascade_SingleSoloScoreOScottish1k('70+ Female', getRaceDataByClassCode(raceData,"UM70F",true)),
+    new Cascade_SingleSoloScoreOScottish1k('70+ Open', getRaceDataByClassCode(raceData,"UM70M",true)),
+    new Cascade_SingleSoloScoreOScottish1k('Open (-21+) Female', getRaceDataByClassCode(raceData,"UOF",true)),
+    new Cascade_SingleSoloScoreOScottish1k('Open (-21+)', getRaceDataByClassCode(raceData,"UOM",true))
+    ])
+}
+
 export const presets = [
     new CompetitionClassPresetButton(
         "COC",
@@ -112,6 +155,20 @@ export const presets = [
         "cascade-UO25-single",
         "2025 Ultimate: Single Event",
         COC_UO25_Single,
+        requireExactlyOneRace
+    ),
+    new CompetitionClassPresetButton(
+        "COC",
+        "cascade-UO25-singleScoreO",
+        "2025 Ultimate: Single ScoreO Event",
+        COC_UO25_SingleScoreO,
+        requireExactlyOneRace
+    ),
+    new CompetitionClassPresetButton(
+        "COC",
+        "cascade-UO22-single",
+        "2022 Ultimate: Single Event",
+        COC_UO22_Single,
         requireExactlyOneRace
     )
 ]

--- a/losttime.web/src/results2/CompetitionClass/Templates/CompetitionClassPresets_Cascade.ts
+++ b/losttime.web/src/results2/CompetitionClass/Templates/CompetitionClassPresets_Cascade.ts
@@ -121,7 +121,7 @@ function COC_UO25_SingleScoreO(raceData:CompetitionClassPresetsProps) {
     ])
 }
 
-function COC_UO22_Single(raceData:CompetitionClassPresetsProps) {
+function COC_UO22_SingleScoreO(raceData:CompetitionClassPresetsProps) {
     raceData.setCompetitionClasses([
     new Standard_ScoreO('Beginner', getRaceDataByClassCode(raceData,"1",true)),
     new Standard_ScoreO('Intermediate', getRaceDataByClassCode(raceData,"2",true)),
@@ -166,9 +166,9 @@ export const presets = [
     ),
     new CompetitionClassPresetButton(
         "COC",
-        "cascade-UO22-single",
-        "2022 Ultimate: Single Event",
-        COC_UO22_Single,
+        "cascade-UO22-singleScoreO",
+        "2022 Ultimate: Single ScoreO Event",
+        COC_UO22_SingleScoreO,
         requireExactlyOneRace
     )
 ]

--- a/losttime.web/src/results2/CompetitionClass/Variants/Cascade_SingleSoloScoreOScottish1k.ts
+++ b/losttime.web/src/results2/CompetitionClass/Variants/Cascade_SingleSoloScoreOScottish1k.ts
@@ -1,0 +1,118 @@
+import { CodeCheckingStatus, CompetitiveStatus } from "../../../results/scoremethods/IofStatusParser";
+import { LtScoreOResult } from "../../../shared/orienteeringtypes/LtScoreOResult";
+import { CompetitionClassType, Results2ScoreMethod } from "../../CompetitionClassType";
+import { Computed_Cascade_SingleSoloScoreOScottish1k } from "../../ComputedCompetitionClass/Computed_Cascade_SingleSoloScoreOScottish1k";
+import { CompetitionClass } from "../CompetitionClass";
+import { SingleRaceSoloScoreOResult } from "../SingleRaceSoloScoreOResult";
+
+export class Cascade_SingleSoloScoreOScottish1k extends CompetitionClass {
+
+    competitionClassType = CompetitionClassType.SingleEventSolo;
+    scoreMethod = Results2ScoreMethod.SingleSolo_ScoreO_Cascade_Scottish1k
+
+    scoreMethodFriendly(): string {
+        return 'Solo - ScoreO - CascadeOC Ultimate'
+    }
+
+    compute():Computed_Cascade_SingleSoloScoreOScottish1k {
+        let results = this.contributingResultsFlat().flatMap(x => 
+            x instanceof LtScoreOResult ? new SingleRaceSoloScoreOResult(x) : []
+        )
+        
+        // sort by score
+        results.sort(this.compareScoreOByScoreThenTime)
+
+        // breakout early
+        if (results.length === 0 ||
+            (results[0].competitive !== CompetitiveStatus.COMP ||
+            results[0].codeChecking !== CodeCheckingStatus.FIN)) {
+            console.log("Nothing here is valid:")
+            console.log(`results: ${results.length}`)
+            if (results.length > 0) {
+                console.log(`status for first: ${results[0].competitive}, ${results[0].codeChecking}`)
+            }
+            return new Computed_Cascade_SingleSoloScoreOScottish1k(this.id, this.name, results);
+        }
+
+        //assign points
+        const bestScore = results[0].score
+        const bestTimeForBestScore = results[0].time
+        const worstTimeForBestScore = results
+            .filter(x=>x.score===bestScore && x.competitive===CompetitiveStatus.COMP)
+            .reduce((maxTime,r)=>r.time > maxTime ? r.time : maxTime, bestTimeForBestScore)
+        results.forEach(x => this.assignPoints(bestScore, bestTimeForBestScore, worstTimeForBestScore, x));
+
+        // assign places
+        results.forEach(this.assignPlace)
+
+        return new Computed_Cascade_SingleSoloScoreOScottish1k(this.id, this.name, results)
+    }
+
+    private assignPoints(bestScore:number, bestTimeForBestScore:number, worstTimeForBestScore:number, r:SingleRaceSoloScoreOResult): void {
+        switch (r.competitive) {
+            case CompetitiveStatus.NC:
+            case CompetitiveStatus.DSQ:
+                break;
+            case CompetitiveStatus.OVT:
+            case CompetitiveStatus.SWD:
+                r.points = 0;
+                break;
+            case CompetitiveStatus.COMP:
+                if (r.codeChecking === CodeCheckingStatus.FIN) {
+                    r.points = CascadeScoreOScottish1kPoints(bestScore, bestTimeForBestScore, worstTimeForBestScore, r.score, r.time)
+                } else {
+                    r.points = 0;
+                }
+        }
+    }
+
+    private assignPlace(
+        r:SingleRaceSoloScoreOResult, 
+        index:number, 
+        results:SingleRaceSoloScoreOResult[]
+    ): void {
+        // no place for NC/DSQ/SPW/
+        if (r.competitive !== CompetitiveStatus.COMP) {
+            return
+        // no place for MSP/DNF/UNK 
+        } else if (r.codeChecking !== CodeCheckingStatus.FIN) {
+            return
+        } else {
+            if (index === 0) {
+                r.place = 1
+            }
+            else {
+                if (r.score === results[index-1].score && r.time === results[index-1].time) {
+                    r.place = results[index-1].place
+                }
+                else {
+                    r.place = index + 1;
+                }
+            }
+        }
+    }
+
+    private compareScoreOByScoreThenTime(a:SingleRaceSoloScoreOResult, b:SingleRaceSoloScoreOResult): number {
+        if (a.competitive !== b.competitive) {
+            return a.competitive - b.competitive;
+        }
+        if (a.codeChecking !== b.codeChecking) {
+            return a.codeChecking - b.codeChecking;
+        }
+        if (a.score !== b.score) {
+            return b.score - a.score // reverse: higher score better
+        } else {
+            return a.time - b.time // shorter time better
+        }
+
+    }
+}
+
+function CascadeScoreOScottish1kPoints(bestScore:number, bestTimeForBestScore:number, worstTimeForBestScore:number, score:number, time:number): number {
+    if (score === bestScore) {
+        return Math.round(bestTimeForBestScore / time * 1000)
+    } else {
+        const worstPointsForBestScore = Math.round(bestTimeForBestScore / worstTimeForBestScore * 1000)
+        return Math.round(score / bestScore * worstPointsForBestScore)
+    }
+}

--- a/losttime.web/src/results2/CompetitionClass/Variants/Cascade_SingleSoloScottish1k.ts
+++ b/losttime.web/src/results2/CompetitionClass/Variants/Cascade_SingleSoloScottish1k.ts
@@ -2,8 +2,9 @@ import { CompetitionClass } from "../CompetitionClass";
 import { Computed_Cascade_SingleSoloPointed } from "../../ComputedCompetitionClass/Computed_Cascade_SingleSoloPointed";
 import { compareSingleSoloByTime } from "../SingleRaceSoloResult";
 import { CodeCheckingStatus, CompetitiveStatus } from "../../../results/scoremethods/IofStatusParser";
-import { SingleRaceSoloPointedResult } from "../SingleRaceSoloPointedResult";
+import { SingleRaceSoloResult } from "../SingleRaceSoloResult";
 import { CompetitionClassType, Results2ScoreMethod } from "../../CompetitionClassType";
+import { LtResult } from "../../../shared/orienteeringtypes/LtResult";
 
 
 export class Cascade_SingleSoloScottish1k extends CompetitionClass {
@@ -12,23 +13,24 @@ export class Cascade_SingleSoloScottish1k extends CompetitionClass {
     scoreMethod = Results2ScoreMethod.SingleSolo_Cascade_Scottish1k
 
     scoreMethodFriendly(): string {
-        return 'Solo - Points - CascadeOC 1000 Ratio to Winner'
+        return 'Solo - CascadeOC Ultimate'
     }
 
     compute():Computed_Cascade_SingleSoloPointed {
         // gather all Single Race Solo Results head to head
         let results = this.contributingResultsFlat().map(x =>
-            new SingleRaceSoloPointedResult(x)
+            new SingleRaceSoloResult(x)
         )
 
+        // order by time
+        results.sort(compareSingleSoloByTime);
+        
+        // break out early if no results, no finishers, or no competitive
         if (results.length === 0 || 
             (results[0].competitive !== CompetitiveStatus.COMP ||
             results[0].codeChecking !== CodeCheckingStatus.FIN)) {
             return new Computed_Cascade_SingleSoloPointed(this.id, this.name, results);
         }
-
-        // order by time
-        results.sort(compareSingleSoloByTime);
 
         // assign points
         const bestTime = results[0].time
@@ -40,11 +42,10 @@ export class Cascade_SingleSoloScottish1k extends CompetitionClass {
         return new Computed_Cascade_SingleSoloPointed(this.id, this.name, results);
     }
 
-    assignPoints(bestTime:number, item:SingleRaceSoloPointedResult): void {
+    private assignPoints(bestTime:number, item:SingleRaceSoloResult): void {
         switch (item.competitive) {
             case CompetitiveStatus.NC:
             case CompetitiveStatus.DSQ:
-                item.points = null;
                 break;
             case CompetitiveStatus.OVT:
             case CompetitiveStatus.SWD:
@@ -59,10 +60,10 @@ export class Cascade_SingleSoloScottish1k extends CompetitionClass {
         }
     }
 
-    assignPlace(
-        item:SingleRaceSoloPointedResult, 
+    private assignPlace(
+        item:SingleRaceSoloResult, 
         index:number, 
-        results:SingleRaceSoloPointedResult[]
+        results:SingleRaceSoloResult[]
     ): void {
         // no place for NC/DSQ/SPW/
         if (item.competitive !== CompetitiveStatus.COMP) {
@@ -91,7 +92,7 @@ function CascadeScottish1kPoints(bestTime:number, thisTime:number):number {
     return Math.round(bestTime / thisTime * 1000)
 }
 
-function compareScottish1kPoints(a:SingleRaceSoloPointedResult, b:SingleRaceSoloPointedResult):number {
+function compareScottish1kPoints(a:SingleRaceSoloResult, b:SingleRaceSoloResult):number {
     if (a.competitive !== b.competitive) {
         return a.competitive - b.competitive;
     }

--- a/losttime.web/src/results2/CompetitionClass/Variants/Cascade_SingleSoloScottish1k.ts
+++ b/losttime.web/src/results2/CompetitionClass/Variants/Cascade_SingleSoloScottish1k.ts
@@ -4,7 +4,6 @@ import { compareSingleSoloByTime } from "../SingleRaceSoloResult";
 import { CodeCheckingStatus, CompetitiveStatus } from "../../../results/scoremethods/IofStatusParser";
 import { SingleRaceSoloResult } from "../SingleRaceSoloResult";
 import { CompetitionClassType, Results2ScoreMethod } from "../../CompetitionClassType";
-import { LtResult } from "../../../shared/orienteeringtypes/LtResult";
 
 
 export class Cascade_SingleSoloScottish1k extends CompetitionClass {

--- a/losttime.web/src/results2/CompetitionClass/Variants/Cascade_SingleSoloWorldCup.ts
+++ b/losttime.web/src/results2/CompetitionClass/Variants/Cascade_SingleSoloWorldCup.ts
@@ -2,7 +2,7 @@ import { CompetitionClass } from "../CompetitionClass";
 import { Computed_Cascade_SingleSoloPointed } from "../../ComputedCompetitionClass/Computed_Cascade_SingleSoloPointed";
 import { compareSingleSoloByTime } from "../SingleRaceSoloResult";
 import { CodeCheckingStatus, CompetitiveStatus } from "../../../results/scoremethods/IofStatusParser";
-import { SingleRaceSoloPointedResult } from "../SingleRaceSoloPointedResult";
+import { SingleRaceSoloResult } from "../SingleRaceSoloResult";
 import { CompetitionClassType, Results2ScoreMethod } from "../../CompetitionClassType";
 
 
@@ -12,13 +12,13 @@ export class Cascade_SingleSoloWorldCup extends CompetitionClass {
     scoreMethod = Results2ScoreMethod.SingleSolo_Cascade_WorldCup;
     
     scoreMethodFriendly(): string {
-        return 'Solo - Points - CascadeOC World Cup'
+        return 'Solo - Points - CascadeOC Winter'
     }
 
     compute():Computed_Cascade_SingleSoloPointed {
         // gather all Single Race Solo Results head to head
         let results = this.contributingResultsFlat().map(x =>
-            new SingleRaceSoloPointedResult(x)
+            new SingleRaceSoloResult(x)
         )
 
         // order by time
@@ -34,9 +34,9 @@ export class Cascade_SingleSoloWorldCup extends CompetitionClass {
     }
 
     private assignPlace(
-        item:SingleRaceSoloPointedResult, 
+        item:SingleRaceSoloResult, 
         index:number, 
-        results:SingleRaceSoloPointedResult[]
+        results:SingleRaceSoloResult[]
     ): void {
         // no place for NC/DSQ/SPW/
         if (item.competitive !== CompetitiveStatus.COMP) {
@@ -60,12 +60,11 @@ export class Cascade_SingleSoloWorldCup extends CompetitionClass {
         }
     }
 
-    private assignPoints(item:SingleRaceSoloPointedResult): void {
+    private assignPoints(item:SingleRaceSoloResult): void {
         if (item.place === undefined || item.place === null) {
             switch (item.competitive) {
                 case CompetitiveStatus.NC:
                 case CompetitiveStatus.DSQ:
-                    item.points = null;
                     break;
                 case CompetitiveStatus.COMP:
                 case CompetitiveStatus.OVT:

--- a/losttime.web/src/results2/CompetitionClass/Variants/Cascade_SingleTeamWorldCup.ts
+++ b/losttime.web/src/results2/CompetitionClass/Variants/Cascade_SingleTeamWorldCup.ts
@@ -55,7 +55,7 @@ export class Cascade_SingleTeamWorldCup extends CompetitionClass {
 
     private assignPointsWiolTeams(team:SingleRaceTeamResult): void {
         team.soloResultsAll.sort(compareSingleSoloPointedByPointsHighestFirst)
-        console.log(team)
+        // console.log(team)
         const size = team.soloResultsAll.length > 3 ? 3 : team.soloResultsAll.length
         team.soloResults = team.soloResultsAll
             .slice(0,size) // only top 3 max

--- a/losttime.web/src/results2/CompetitionClass/Variants/Cascade_SingleTeamWorldCup.ts
+++ b/losttime.web/src/results2/CompetitionClass/Variants/Cascade_SingleTeamWorldCup.ts
@@ -1,7 +1,7 @@
 import { Computed_Cascade_SingleTeamPointed } from "../../ComputedCompetitionClass/Computed_Cascade_SingleTeamPointed";
 import { CompetitionClass } from "../CompetitionClass";
 import { SingleRaceTeamResult } from "../SingleRaceTeamResult";
-import { SingleRaceSoloPointedResult } from "../SingleRaceSoloPointedResult";
+import { SingleRaceSoloResult } from "../SingleRaceSoloResult";
 import { Cascade_SingleSoloWorldCup } from "./Cascade_SingleSoloWorldCup";
 import { CompetitiveStatus } from "../../../results/scoremethods/IofStatusParser";
 import { CompetitionClassType, Results2ScoreMethod } from "../../CompetitionClassType";
@@ -13,27 +13,27 @@ export class Cascade_SingleTeamWorldCup extends CompetitionClass {
     scoreMethod = Results2ScoreMethod.SingleTeam_Cascade_WorldCup;
 
     scoreMethodFriendly(): string {
-        return 'Team - CascadeOC World Cup'
+        return 'Team - CascadeOC Winter'
     }
 
     compute():Computed_Cascade_SingleTeamPointed {
-        let solos:SingleRaceSoloPointedResult[] = []
+        let solos:SingleRaceSoloResult[] = []
         this.contributingResults.forEach((c) => {
             //score each class individually
-            const scored = new Cascade_SingleSoloWorldCup(c.xmlClass.ShortName, [c])
+            const scored = new Cascade_SingleSoloWorldCup(c.class.code, [c])
                 .compute()
             solos.push(...scored.results)
         })
 
         // determine all possible teams
         const teamNames = solos.reduce((teams:string[],r): string[] => 
-            teams.some((x) => x === r.club) ? teams : [...teams, r.club]
+            teams.some((x) => x === r.person.clubCode) ? teams : [...teams, r.person.clubCode]
         , [])
 
         // create team result if more than one result for that team.
         let teams:SingleRaceTeamResult[] = []
         teamNames.forEach((t) => {
-            const members = solos.filter((x) => x.club === t 
+            const members = solos.filter((x) => x.person.clubCode === t 
                 && x.competitive !== CompetitiveStatus.NC);
             if (members.length > 1) {
                 teams.push(new SingleRaceTeamResult(members, getClubNameString(t), t))
@@ -112,7 +112,7 @@ function getClubNameString(clubcode:string, checkAllNamespaces:boolean=true, pre
     return res ? res.Name : clubcode
 }
 
-function compareSingleSoloPointedByPointsHighestFirst(a:SingleRaceSoloPointedResult, b:SingleRaceSoloPointedResult) {
+function compareSingleSoloPointedByPointsHighestFirst(a:SingleRaceSoloResult, b:SingleRaceSoloResult) {
     if (a.points && b.points) {
         return b.points - a.points;
     }

--- a/losttime.web/src/results2/CompetitionClass/Variants/Ousa_SingleSoloAvgWinTime.ts
+++ b/losttime.web/src/results2/CompetitionClass/Variants/Ousa_SingleSoloAvgWinTime.ts
@@ -1,10 +1,10 @@
 import { CompetitionClass } from "../CompetitionClass";
 import { StandardRaceClassData } from "../../StandardRaceClassData";
 import { CodeCheckingStatus, CompetitiveStatus } from "../../../results/scoremethods/IofStatusParser";
-import { PersonResult } from "../../../shared/orienteeringtypes/IofResultXml";
 import { Computed_Ousa_SingleSoloAvgWinTime } from "../../ComputedCompetitionClass/Computed_Ousa_SingleSoloAvgWinTime";
-import { SingleRaceSoloPointedResult } from "../SingleRaceSoloPointedResult";
+import { SingleRaceSoloResult } from "../SingleRaceSoloResult";
 import { CompetitionClassType, Results2ScoreMethod } from "../../CompetitionClassType";
+import { LtResult } from "../../../shared/orienteeringtypes/LtResult";
 
 
 export class Ousa_SingleSoloAvgWinTime extends CompetitionClass {
@@ -19,12 +19,12 @@ export class Ousa_SingleSoloAvgWinTime extends CompetitionClass {
         this.consideredResults = consideredResults;
     }
 
-    consideredResultsFlat(): PersonResult[] {
+    consideredResultsFlat(): LtResult[] {
         // like super.contributingResultsFlat
-        let results: PersonResult[] = []
+        let results: LtResult[] = []
         for (const race of this.consideredResults) {
-            if (race.xmlPersonResults.length === undefined) {continue;}
-            results.push(...race.xmlPersonResults);
+            if (race.results.length === undefined) {continue;}
+            results.push(...race.results);
         }
         return results
     }
@@ -38,10 +38,10 @@ export class Ousa_SingleSoloAvgWinTime extends CompetitionClass {
     compute(): Computed_Ousa_SingleSoloAvgWinTime {
         // gather all Single Race Solo Results head to head
         let results = this.contributingResultsFlat().map(x =>
-            new SingleRaceSoloPointedResult(x)
+            new SingleRaceSoloResult(x)
         )
         let pairedResults = this.consideredResultsFlat().map(x =>
-            new SingleRaceSoloPointedResult(x)
+            new SingleRaceSoloResult(x)
         )
 
         // do AWT calcs for this class
@@ -58,7 +58,7 @@ export class Ousa_SingleSoloAvgWinTime extends CompetitionClass {
 
 
 //from OusaAwt.tsx
-function CalcAwtForClass(raceResults:SingleRaceSoloPointedResult[]):number|undefined {
+function CalcAwtForClass(raceResults:SingleRaceSoloResult[]):number|undefined {
     const valids = raceResults.filter(x => x.competitive === CompetitiveStatus.COMP && x.codeChecking === CodeCheckingStatus.FIN && x.time)
 
     if (!valids || !valids.length) {
@@ -67,7 +67,7 @@ function CalcAwtForClass(raceResults:SingleRaceSoloPointedResult[]):number|undef
 
     valids.sort((a,b) => a.time - b.time)
 
-    let topFinishers:SingleRaceSoloPointedResult[] = [];
+    let topFinishers:SingleRaceSoloResult[] = [];
     const maxToConsider:number = valids.length > 3 ? 3 : valids.length;
     topFinishers = valids.slice(0,maxToConsider);
 

--- a/losttime.web/src/results2/CompetitionClass/Variants/Standard_ScoreO.ts
+++ b/losttime.web/src/results2/CompetitionClass/Variants/Standard_ScoreO.ts
@@ -1,0 +1,78 @@
+import { CodeCheckingStatus, CompetitiveStatus } from "../../../results/scoremethods/IofStatusParser";
+import { LtScoreOResult } from "../../../shared/orienteeringtypes/LtScoreOResult";
+import { CompetitionClassType, Results2ScoreMethod } from "../../CompetitionClassType";
+import { Computed_Standard_ScoreO } from "../../ComputedCompetitionClass/Computed_Standard_ScoreO";
+import { CompetitionClass } from "../CompetitionClass";
+import { SingleRaceSoloScoreOResult } from "../SingleRaceSoloScoreOResult";
+
+export class Standard_ScoreO extends CompetitionClass {
+
+    competitionClassType = CompetitionClassType.SingleEventSolo;
+    scoreMethod = Results2ScoreMethod.SingleSolo_ScoreO
+
+    scoreMethodFriendly(): string {
+        return 'Solo - ScoreO'
+    }
+
+    compute():Computed_Standard_ScoreO {
+        let results = this.contributingResultsFlat().flatMap(x => 
+            x instanceof LtScoreOResult ? new SingleRaceSoloScoreOResult(x) : []
+        )
+        
+        // sort by score
+        results.sort(this.compareScoreOByScoreThenTime)
+
+        // breakout early
+        if (results.length === 0 ||
+            (results[0].competitive !== CompetitiveStatus.COMP ||
+            results[0].codeChecking !== CodeCheckingStatus.FIN)) {
+            return new Computed_Standard_ScoreO(this.id, this.name, results);
+        }
+
+        // assign places
+        results.forEach(this.assignPlace)
+
+        return new Computed_Standard_ScoreO(this.id, this.name, results)
+    }
+
+    private assignPlace(
+        r:SingleRaceSoloScoreOResult, 
+        index:number, 
+        results:SingleRaceSoloScoreOResult[]
+    ): void {
+        // no place for NC/DSQ/SPW/
+        if (r.competitive !== CompetitiveStatus.COMP) {
+            return
+        // no place for MSP/DNF/UNK 
+        } else if (r.codeChecking !== CodeCheckingStatus.FIN) {
+            return
+        } else {
+            if (index === 0) {
+                r.place = 1
+            }
+            else {
+                if (r.score === results[index-1].score && r.time === results[index-1].time) {
+                    r.place = results[index-1].place
+                }
+                else {
+                    r.place = index + 1;
+                }
+            }
+        }
+    }
+
+    private compareScoreOByScoreThenTime(a:SingleRaceSoloScoreOResult, b:SingleRaceSoloScoreOResult): number {
+        if (a.competitive !== b.competitive) {
+            return a.competitive - b.competitive;
+        }
+        if (a.codeChecking !== b.codeChecking) {
+            return a.codeChecking - b.codeChecking;
+        }
+        if (a.score !== b.score) {
+            return b.score - a.score // reverse: higher score better
+        } else {
+            return a.time - b.time // shorter time better
+        }
+
+    }
+}

--- a/losttime.web/src/results2/CompetitionClassType.ts
+++ b/losttime.web/src/results2/CompetitionClassType.ts
@@ -9,5 +9,7 @@ export enum Results2ScoreMethod {
     SingleSolo_Time,
     SingleSolo_Cascade_WorldCup,
     SingleSolo_Cascade_Scottish1k,
+    SingleSolo_ScoreO,
+    SingleSolo_ScoreO_Cascade_Scottish1k,
     SingleTeam_Cascade_WorldCup
 }

--- a/losttime.web/src/results2/Components/Compose/CompetitionClassComposer.tsx
+++ b/losttime.web/src/results2/Components/Compose/CompetitionClassComposer.tsx
@@ -15,6 +15,8 @@ import { Cascade_SingleTeamWorldCup } from "../../CompetitionClass/Variants/Casc
 import { WizardSectionTitle } from "../../../shared/WizardSectionTitle";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faChevronDown, faChevronUp } from "@fortawesome/free-solid-svg-icons";
+import { Standard_ScoreO } from "../../CompetitionClass/Variants/Standard_ScoreO";
+import { Cascade_SingleSoloScoreOScottish1k } from "../../CompetitionClass/Variants/Cascade_SingleSoloScoreOScottish1k";
 
 export type raceClassesByRace = Map<Guid,Map<string,StandardRaceClassData>>;
 
@@ -27,7 +29,7 @@ function getUniqueClassLabels(raceClassesByRace:raceClassesByRace) {
     let classLabels:Map<string, string> = new Map();
     [...raceClassesByRace].map(([raceid,raceClasses]) =>
         [...raceClasses].map(([shortName,raceClass]) =>
-            classLabels.set(raceClass.xmlClass.ShortName, raceClass.xmlClass.Name)
+            classLabels.set(raceClass.class.code, raceClass.class.name)
         )
     );
     const sorted = [...classLabels.keys()].sort();
@@ -144,7 +146,7 @@ export function CompetitionClassComposer(props:CompetitionClassComposerProps) {
             case Results2ScoreMethod.SingleSolo_Time :
                 props.setCompetitionClasses((current:CompetitionClass[]) => 
                     [...current, new Standard_Time(
-                        `${getRaceClassDataForSelected()[0]!.xmlClass.Name}`+
+                        `${getRaceClassDataForSelected()[0]!.class.name}`+
                         `${getRaceClassDataForSelected().length > 1 ? " and More" : ""}`, 
                         getRaceClassDataForSelected()
                     )]
@@ -153,7 +155,7 @@ export function CompetitionClassComposer(props:CompetitionClassComposerProps) {
             case Results2ScoreMethod.SingleSolo_Cascade_WorldCup :
                 props.setCompetitionClasses((current:CompetitionClass[]) => 
                     [...current, new Cascade_SingleSoloWorldCup(
-                        `${getRaceClassDataForSelected()[0]!.xmlClass.Name}`+
+                        `${getRaceClassDataForSelected()[0]!.class.name}`+
                         `${getRaceClassDataForSelected().length > 1 ? " and More" : ""}`,
                         getRaceClassDataForSelected()
                     )]
@@ -162,7 +164,7 @@ export function CompetitionClassComposer(props:CompetitionClassComposerProps) {
             case Results2ScoreMethod.SingleSolo_Cascade_Scottish1k :
                 props.setCompetitionClasses((current:CompetitionClass[]) => 
                     [...current, new Cascade_SingleSoloScottish1k(
-                        `${getRaceClassDataForSelected()[0]!.xmlClass.Name}`+
+                        `${getRaceClassDataForSelected()[0]!.class.name}`+
                         `${getRaceClassDataForSelected().length > 1 ? " and More" : ""}`,
                         getRaceClassDataForSelected()
                     )]
@@ -171,7 +173,25 @@ export function CompetitionClassComposer(props:CompetitionClassComposerProps) {
             case Results2ScoreMethod.SingleTeam_Cascade_WorldCup :
                 props.setCompetitionClasses((current:CompetitionClass[]) => 
                     [...current, new Cascade_SingleTeamWorldCup(
-                        `${getRaceClassDataForSelected()[0]!.xmlClass.Name}`+
+                        `${getRaceClassDataForSelected()[0]!.class.name}`+
+                        `${getRaceClassDataForSelected().length > 1 ? " and More" : ""}`,
+                        getRaceClassDataForSelected()
+                    )]
+                );
+                break;
+            case Results2ScoreMethod.SingleSolo_ScoreO :
+                props.setCompetitionClasses((current:CompetitionClass[]) =>
+                    [...current, new Standard_ScoreO(
+                        `${getRaceClassDataForSelected()[0]!.class.name}`+
+                        `${getRaceClassDataForSelected().length > 1 ? " and More" : ""}`,
+                        getRaceClassDataForSelected()
+                    )]
+                );
+                break;
+            case Results2ScoreMethod.SingleSolo_ScoreO_Cascade_Scottish1k :
+                props.setCompetitionClasses((current:CompetitionClass[]) =>
+                    [...current, new Cascade_SingleSoloScoreOScottish1k(
+                        `${getRaceClassDataForSelected()[0]!.class.name}`+
                         `${getRaceClassDataForSelected().length > 1 ? " and More" : ""}`,
                         getRaceClassDataForSelected()
                     )]

--- a/losttime.web/src/results2/Components/Compose/CompetitionClassPresetsCustom.tsx
+++ b/losttime.web/src/results2/Components/Compose/CompetitionClassPresetsCustom.tsx
@@ -23,7 +23,7 @@ export function CompetitionClassPresetsCustom(props:CompetitionClassPresetsProps
 
     const liveButtons = buttons.map((x) => {
         if (x.org === org) {
-            return <Col sm={12} md={6} key={`${x.id}-container`}>
+            return <Col sm={12} lg={6} key={`${x.id}-container`} className="mb-1">
                 <Button
                     key={x.id}
                     id={x.id}

--- a/losttime.web/src/results2/Components/Compose/CompetitionClassPresetsStandard.tsx
+++ b/losttime.web/src/results2/Components/Compose/CompetitionClassPresetsStandard.tsx
@@ -18,7 +18,7 @@ export function CompetitionClassPresetsStandard(props:CompetitionClassPresetsPro
         props.raceClassesByClass.forEach((data, name) => {
             if (data.length === 1 && data[0] !== undefined) {
                 props.setCompetitionClasses((current:CompetitionClass[]) =>
-                    [...current, new Standard_Time(data[0]!.xmlClass.Name,[data[0]!])]
+                    [...current, new Standard_Time(data[0]!.class.name,[data[0]!])]
                 )
             }
         })

--- a/losttime.web/src/results2/Components/Compose/ScoreMethodSelect.tsx
+++ b/losttime.web/src/results2/Components/Compose/ScoreMethodSelect.tsx
@@ -6,9 +6,15 @@ interface ScoreMethodSelectProps {
 }
 
 export const scoreMethodOptions = [
+    <option>-- Standard --</option>,
     <option key={`score-option-${Results2ScoreMethod.SingleSolo_Time}`} value={Results2ScoreMethod.SingleSolo_Time}>Solo - Time</option>,
-    <option key={`score-option-${Results2ScoreMethod.SingleSolo_Cascade_WorldCup}`} value={Results2ScoreMethod.SingleSolo_Cascade_WorldCup}>Solo - Points - CascadeOC World Cup</option>,
-    <option key={`score-option-${Results2ScoreMethod.SingleTeam_Cascade_WorldCup}`} value={Results2ScoreMethod.SingleTeam_Cascade_WorldCup}>Team - Cascade - World Cup</option>
+    
+    <option key={`score-option-${Results2ScoreMethod.SingleSolo_Cascade_WorldCup}`} value={Results2ScoreMethod.SingleSolo_Cascade_WorldCup}>Solo - CascadeOC Winter</option>,
+    <option>-- Score O --</option>,
+    <option key={`score-option-${Results2ScoreMethod.SingleSolo_ScoreO}`} value={Results2ScoreMethod.SingleSolo_ScoreO}>Solo - ScoreO</option>,
+    <option key={`score-option-${Results2ScoreMethod.SingleSolo_ScoreO_Cascade_Scottish1k}`} value={Results2ScoreMethod.SingleSolo_ScoreO_Cascade_Scottish1k}>Solo - ScoreO - CascadeOC Ultimate</option>,
+    <option>-- Team Scoring --</option>,
+    <option key={`score-option-${Results2ScoreMethod.SingleTeam_Cascade_WorldCup}`} value={Results2ScoreMethod.SingleTeam_Cascade_WorldCup}>Team - Cascade - Winter</option>
 ];
 
 export function ScoreMethodSelect(props:ScoreMethodSelectProps) {

--- a/losttime.web/src/results2/Components/Compose/ScoreMethodSelect.tsx
+++ b/losttime.web/src/results2/Components/Compose/ScoreMethodSelect.tsx
@@ -6,14 +6,14 @@ interface ScoreMethodSelectProps {
 }
 
 export const scoreMethodOptions = [
-    <option>-- Standard --</option>,
+    <option key="list-sep-standard">-- Standard --</option>,
     <option key={`score-option-${Results2ScoreMethod.SingleSolo_Time}`} value={Results2ScoreMethod.SingleSolo_Time}>Solo - Time</option>,
     
     <option key={`score-option-${Results2ScoreMethod.SingleSolo_Cascade_WorldCup}`} value={Results2ScoreMethod.SingleSolo_Cascade_WorldCup}>Solo - CascadeOC Winter</option>,
-    <option>-- Score O --</option>,
+    <option key="list-sep-scoreo">-- Score O --</option>,
     <option key={`score-option-${Results2ScoreMethod.SingleSolo_ScoreO}`} value={Results2ScoreMethod.SingleSolo_ScoreO}>Solo - ScoreO</option>,
     <option key={`score-option-${Results2ScoreMethod.SingleSolo_ScoreO_Cascade_Scottish1k}`} value={Results2ScoreMethod.SingleSolo_ScoreO_Cascade_Scottish1k}>Solo - ScoreO - CascadeOC Ultimate</option>,
-    <option>-- Team Scoring --</option>,
+    <option key="list-sep-team">-- Team Scoring --</option>,
     <option key={`score-option-${Results2ScoreMethod.SingleTeam_Cascade_WorldCup}`} value={Results2ScoreMethod.SingleTeam_Cascade_WorldCup}>Team - Cascade - Winter</option>
 ];
 

--- a/losttime.web/src/results2/Components/Compose/SelectableRaceClass.tsx
+++ b/losttime.web/src/results2/Components/Compose/SelectableRaceClass.tsx
@@ -18,6 +18,6 @@ export function SelectableRaceClass(props:SelectableRaceClassProps) {
         value={props.raceClass.id.toString()}
         onChange={(e) => props.onChange(e)}
     >
-    {props.raceClass.xmlClass.Name} - {props.raceClass.xmlPersonResults.length} Results
+    {props.raceClass.class.name} - {props.raceClass.results.length} Results
   </ToggleButton>
 }

--- a/losttime.web/src/results2/Components/FileLoader.tsx
+++ b/losttime.web/src/results2/Components/FileLoader.tsx
@@ -1,14 +1,20 @@
 import { XMLParser } from "fast-xml-parser";
 import { useCallback, useState } from "react";
 import { useDropzone } from "react-dropzone";
+import { parse as PapaParse, RECORD_SEP, UNIT_SEP, ParseResult, ParseLocalConfig, LocalFile } from "papaparse"
 import { StandardRaceClassData } from "../StandardRaceClassData";
 import { Guid } from "guid-typescript";
-import { ClassResult } from "../../shared/orienteeringtypes/IofResultXml";
+import { ClassResult, IofXml3ToLtResult } from "../../shared/orienteeringtypes/IofResultXml";
 import { Button, Col, Row } from "react-bootstrap";
 import { WizardSectionTitle } from "../../shared/WizardSectionTitle";
 import { raceClassesByRace } from "./Compose/CompetitionClassComposer";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faRotateLeft } from "@fortawesome/free-solid-svg-icons";
+import { OESco0012, OEScoCsvToLtScoreOResult } from "../../shared/orienteeringtypes/OESco0012";
+import { LtRaceClass } from "../../shared/orienteeringtypes/LtRaceClass";
+import { LtCourse } from "../../shared/orienteeringtypes/LtCourse";
+import { LtResult } from "../../shared/orienteeringtypes/LtResult";
+
 
 interface FileLoaderProps {
     raceClassesByRace: raceClassesByRace
@@ -39,6 +45,59 @@ interface loadedFile {
     race_id: Guid
 }
 
+function handleCsvFile(results:ParseResult<any>, file:File, setFilesState:Function, fileLoaderProps:FileLoaderProps) {
+    const race_id = Guid.create();
+    const race_name = file.name
+    
+    // detect what type of file this is
+    if (results.meta.fields && results.meta.fields[0] === "OESco0012") {
+        
+        // get all the unique class values
+        // TODO: there's probably a better way to do deep compare rather than this string mess
+        //       or I could just not care and look only at codes and join back to the first 
+        //       instance of the name, but I'd rather avoid that pattern
+        const allClassNames = results.data.map((x:OESco0012) => `${x.Short}::${(x.Long)}`)
+        const uniqueClassNames:string[] = allClassNames.filter((val, idx, arr) => arr.indexOf(val) === idx);
+        const uniqueLtClasses:LtRaceClass[] = uniqueClassNames.map(s => {
+            const [code,name] = s.split("::",2)
+            return new LtRaceClass(name,code)
+        })
+        uniqueLtClasses.sort((a,b) => a.code.localeCompare(b.code));
+
+        // iterate through those to create StandardRaceClassData for each class
+        const raceClasses: StandardRaceClassData[] = uniqueLtClasses.map((classInfo:LtRaceClass) =>
+            new StandardRaceClassData(
+                {id:race_id,name:race_name},
+                classInfo,
+                results.data.filter((x:OESco0012) => x.Short===classInfo.code).map(OEScoCsvToLtScoreOResult)
+        ))
+
+        setFilesState((existing:loadedFile[]) => 
+            [...existing, {filename:file.name, data:raceClasses, race_id: race_id}])
+
+        let raceClassesMap:Map<string,StandardRaceClassData> = new Map()
+        raceClasses.forEach((el) =>
+            // without toString() here, a ShortName of 1 ends up as an
+            // integer type key in the map, causing things to break later.
+            raceClassesMap.set(el.class.code.toString(), el))
+            fileLoaderProps.setRaceClasses((existing: Map<Guid,Map<string,StandardRaceClassData>>) => {
+                // https://expertbeacon.com/re-render-react-component-when-its-props-changes-a-comprehensive-guide/
+                // if an array prop is passed from parent -> child and mutated in place, the child will not re-render
+                // so to add to the map, I can't just Map.set(key,value) - have to build a new Map.
+                // this forces the component that gets passed this state as a prop to re-render.
+                var updated = new Map()
+                existing.forEach((value, key) =>
+                    updated.set(key, value)
+                )
+                updated.set(race_id, raceClassesMap);
+                return updated;
+            })
+    } else {
+        alert("Sorry, don't support generic CSV files yet. Only OEScore csv files.")
+        return
+    }
+}
+
 export function FileLoader(props: FileLoaderProps) {
 
     const [files, setFiles] = useState<loadedFile[]>([])
@@ -51,40 +110,61 @@ export function FileLoader(props: FileLoaderProps) {
             reader.onabort = () => console.log("file reading aborted");
             reader.onerror = () => console.log("file reader error");
             reader.onload = () => {
-                const parserOptions: any = {
-                    ignoreAttributes: false,
-                }
-                const parser = new XMLParser(parserOptions);
-                const resultsObj = parser.parse(reader.result as string);
 
-                const race_id = Guid.create();
-                const race_name = resultsObj.ResultList.Event.Name
-
-                const raceClasses: StandardRaceClassData[] = resultsObj.ResultList.ClassResult.map((el: ClassResult) =>
-                    new StandardRaceClassData({ id: race_id, name: race_name }, el)
-                )
-
-                setFiles((existing) => 
-                    [...existing, {filename:file.name, data:raceClasses, race_id: race_id}])
-
-                let raceClassesMap:Map<string,StandardRaceClassData> = new Map()
-                raceClasses.forEach((el) =>
-                    // without toString() here, a ShortName of 1 ends up as an
-                    // integer type key in the map, causing things to break later.
-                    raceClassesMap.set(el.xmlClass.ShortName.toString(), el))
-
-                props.setRaceClasses((existing: Map<Guid,Map<string,StandardRaceClassData>>) => {
-                    // https://expertbeacon.com/re-render-react-component-when-its-props-changes-a-comprehensive-guide/
-                    // if an array prop is passed from parent -> child and mutated in place, the child will not re-render
-                    // so to add to the map, I can't just Map.set(key,value) - have to build a new Map.
-                    // this forces the component that gets passed this state as a prop to re-render.
-                    var updated = new Map()
-                    existing.forEach((value, key) =>
-                        updated.set(key, value)
+                if (file.name.slice(-4) === ".xml") {
+                    const parserOptions: any = {
+                        ignoreAttributes: false,
+                    }
+                    const parser = new XMLParser(parserOptions);
+                    const resultsObj = parser.parse(reader.result as string);
+    
+                    const race_id = Guid.create();
+                    const race_name = resultsObj.ResultList.Event.Name
+    
+                    const raceClasses: StandardRaceClassData[] = resultsObj.ResultList.ClassResult.map((el: ClassResult) =>
+                        new StandardRaceClassData(
+                            { id: race_id, name: race_name },
+                            new LtRaceClass(el.Class.Name, el.Class.ShortName),
+                            [el.PersonResult].flat().map(IofXml3ToLtResult),
+                            new LtCourse(el.Course.Name, el.Course.NumberOfControls, el.Course.Length, el.Course.Climb)
+                        )
                     )
-                    updated.set(race_id, raceClassesMap);
-                    return updated;
-                })
+    
+                    setFiles((existing) => 
+                        [...existing, {filename:file.name, data:raceClasses, race_id: race_id}])
+    
+                    let raceClassesMap:Map<string,StandardRaceClassData> = new Map()
+                    raceClasses.forEach((el) =>
+                        // without toString() here, a ShortName of 1 ends up as an
+                        // integer type key in the map, causing things to break later.
+                        raceClassesMap.set(el.class.code.toString(), el))
+    
+                    props.setRaceClasses((existing: Map<Guid,Map<string,StandardRaceClassData>>) => {
+                        // https://expertbeacon.com/re-render-react-component-when-its-props-changes-a-comprehensive-guide/
+                        // if an array prop is passed from parent -> child and mutated in place, the child will not re-render
+                        // so to add to the map, I can't just Map.set(key,value) - have to build a new Map.
+                        // this forces the component that gets passed this state as a prop to re-render.
+                        var updated = new Map()
+                        existing.forEach((value, key) =>
+                            updated.set(key, value)
+                        )
+                        updated.set(race_id, raceClassesMap);
+                        return updated;
+                    })
+                } else if (file.name.slice(-4) === ".csv") {
+                    const config:ParseLocalConfig<any, LocalFile> = {
+                        header: true,
+                        dynamicTyping: false,
+                        complete: (r) => handleCsvFile(r,file,setFiles, props),
+                        skipEmptyLines: "greedy",
+                        transform: (value:any, col:any) => {return(value.replace(/\0/g, '').trim())},
+                        delimitersToGuess: [',', '\t', '|', ';', RECORD_SEP, UNIT_SEP]
+                    }
+                    PapaParse<any>(file, config);
+                } else {
+                    alert(`Sorry, ${file.name} is not a supported file type.`);
+                    console.log(`${file.name} is not supported.`);
+                }
             }
             reader.readAsText(file);
         })
@@ -94,9 +174,7 @@ export function FileLoader(props: FileLoaderProps) {
 
     const fileItems = files.map((x) => {
         let classes = "";
-        x.data.forEach((c) =>
-            classes += `${c.xmlClass.ShortName}, `
-        )
+        x.data.forEach((c) => {classes += `${c.class.code}, `})
         classes = classes.slice(0,-2);
         return <li key={x.race_id.toString()}><strong>{x.filename}</strong> with <strong>{x.data.length.toString()}</strong> classes: {classes}</li>
     });
@@ -114,7 +192,7 @@ export function FileLoader(props: FileLoaderProps) {
             <WizardSectionTitle title="Load Results File(s)" showLine={false} icon={icon}/>
             
             <Col md={12} lg={5}>
-            <p>Add Orienteering Results or Splits files in the <strong>IOF XML v3</strong> format.</p>
+            <p>Add Orienteering Results or Splits files in the <strong>IOF XML v3</strong> format.<br/>Add ScoreO results from Sport Software OE Score in <strong>OESco0012 csv</strong> format.</p>
             <div {...getRootProps({ className: 'dropzone', style: baseStyle })}>
                 <input id="dz-file-input" {...getInputProps()} />
                 {

--- a/losttime.web/src/results2/Components/FileLoader.tsx
+++ b/losttime.web/src/results2/Components/FileLoader.tsx
@@ -13,7 +13,6 @@ import { faRotateLeft } from "@fortawesome/free-solid-svg-icons";
 import { OESco0012, OEScoCsvToLtScoreOResult } from "../../shared/orienteeringtypes/OESco0012";
 import { LtRaceClass } from "../../shared/orienteeringtypes/LtRaceClass";
 import { LtCourse } from "../../shared/orienteeringtypes/LtCourse";
-import { LtResult } from "../../shared/orienteeringtypes/LtResult";
 
 
 interface FileLoaderProps {

--- a/losttime.web/src/results2/Components/Output/OutputBuilder.tsx
+++ b/losttime.web/src/results2/Components/Output/OutputBuilder.tsx
@@ -19,6 +19,8 @@ import { Results2ScoreMethod } from "../../CompetitionClassType";
 import { Cascade_SingleTeamWorldCup } from "../../CompetitionClass/Variants/Cascade_SingleTeamWorldCup";
 import { WizardSectionTitle } from "../../../shared/WizardSectionTitle";
 import { scoreMethodOptions } from "../Compose/ScoreMethodSelect";
+import { Standard_ScoreO } from "../../CompetitionClass/Variants/Standard_ScoreO";
+import { Cascade_SingleSoloScoreOScottish1k } from "../../CompetitionClass/Variants/Cascade_SingleSoloScoreOScottish1k";
 
 interface outputBuilderProps {
     competitionClasses:CompetitionClass[]
@@ -98,6 +100,12 @@ export function OutputBuilder(props:outputBuilderProps) {
                     break;
                 case Results2ScoreMethod.SingleTeam_Cascade_WorldCup.toString():
                     next = new Cascade_SingleTeamWorldCup(old.name, old.contributingResults);
+                    break;
+                case Results2ScoreMethod.SingleSolo_ScoreO.toString():
+                    next = new Standard_ScoreO(old.name, old.contributingResults);
+                    break;
+                case Results2ScoreMethod.SingleSolo_ScoreO_Cascade_Scottish1k.toString():
+                    next = new Cascade_SingleSoloScoreOScottish1k(old.name, old.contributingResults);
                     break;
                 default:
                     new Error("Can't change to that score method")

--- a/losttime.web/src/results2/ComputedCompetitionClass/Computed_Cascade_SingleSoloPointed.ts
+++ b/losttime.web/src/results2/ComputedCompetitionClass/Computed_Cascade_SingleSoloPointed.ts
@@ -1,6 +1,6 @@
 import { Guid } from "guid-typescript";
 import { ComputedCompetitionClass } from "./ComputedCompetitionClass";
-import { SingleRaceSoloPointedResult } from "../CompetitionClass/SingleRaceSoloPointedResult";
+import { SingleRaceSoloResult } from "../CompetitionClass/SingleRaceSoloResult";
 import { RenderStyles } from "../Styles/RenderStyles";
 import { PlaintextColumn } from "../Styles/PlaintextColumn";
 import { PlaintextTable } from "../Styles/PlaintextTable";
@@ -9,19 +9,12 @@ import { HtmlTable } from "../Styles/HtmlTable";
 
 export class Computed_Cascade_SingleSoloPointed extends ComputedCompetitionClass {
 
-    results: SingleRaceSoloPointedResult[]
+    results: SingleRaceSoloResult[]
 
-    constructor(competitionClassId:Guid, name:string, r: SingleRaceSoloPointedResult[]) {
+    constructor(competitionClassId:Guid, name:string, r: SingleRaceSoloResult[]) {
         super(competitionClassId, name, r);
         this.results = r
     }
-
-    private getPlace = (r:SingleRaceSoloPointedResult):string => `${r.place ?? ""}`
-    private getNameClub = (r:SingleRaceSoloPointedResult):string => `${r.name} (${r.club})`
-    private getName = (r:SingleRaceSoloPointedResult):string => `${r.name}`
-    private getClub = (r:SingleRaceSoloPointedResult):string => `${r.club}`
-    private getTime = (r:SingleRaceSoloPointedResult):string => `${this.timeWithStatusString(r)}`
-    private getPoints = (r:SingleRaceSoloPointedResult):string => `${r.points ?? ""}`
 
     render(style:RenderStyles): string {
         switch (style) {
@@ -48,24 +41,24 @@ export class Computed_Cascade_SingleSoloPointed extends ComputedCompetitionClass
 
         const PL = new PlaintextColumn(
             "Pl",
-            this.getPlace,
+            SingleRaceSoloResult.getPlace,
             this.results,
             "start")
 
         const NAME = new PlaintextColumn(
             "Name",
-            this.getNameClub,
+            SingleRaceSoloResult.getNameClub,
             this.results)
         
         const TIME = new PlaintextColumn(
             "Time",
-            this.getTime,
+            SingleRaceSoloResult.getTimeWithStatus,
             this.results,
             "start")
 
         const PTS = new PlaintextColumn(
             "Pts",
-            this.getPoints,
+            SingleRaceSoloResult.getPoints,
             this.results,
             "start")
 
@@ -88,20 +81,20 @@ export class Computed_Cascade_SingleSoloPointed extends ComputedCompetitionClass
 
         const PL = new HtmlColumn(
             "Place", 
-            this.getPlace
+            SingleRaceSoloResult.getPlace
         )
         const NAME = new HtmlColumn(
             "Name",
-            this.getNameClub
+            SingleRaceSoloResult.getNameClub
         )
         const TIME = new HtmlColumn(
             "Time",
-            this.getTime,
+            SingleRaceSoloResult.getTimeWithStatus,
             "text-right"
         )
         const PTS = new HtmlColumn(
             "Points",
-            this.getPoints,
+            SingleRaceSoloResult.getPoints,
             "text-right"
         )
         const table = new HtmlTable([PL,NAME,TIME,PTS],this,this.results).doc
@@ -126,24 +119,24 @@ export class Computed_Cascade_SingleSoloPointed extends ComputedCompetitionClass
 
         const PL = new HtmlColumn(
             "Pos", 
-            this.getPlace
+            SingleRaceSoloResult.getPlace
         )
         const NAME = new HtmlColumn(
             "Name",
-            this.getName
+            SingleRaceSoloResult.getName
         )
         const CLUB = new HtmlColumn(
             "Club",
-            this.getClub
+            SingleRaceSoloResult.getClubCode
         )
         const TIME = new HtmlColumn(
             "Time",
-            this.getTime,
+            SingleRaceSoloResult.getTimeWithStatus,
             "text-right"
         )
         const PTS = new HtmlColumn(
             "Score",
-            this.getPoints,
+            SingleRaceSoloResult.getPoints,
             "text-right"
         )
         const table = new HtmlTable([PL,NAME,CLUB,TIME,PTS],this,this.results).doc

--- a/losttime.web/src/results2/ComputedCompetitionClass/Computed_Cascade_SingleSoloScoreOScottish1k.ts
+++ b/losttime.web/src/results2/ComputedCompetitionClass/Computed_Cascade_SingleSoloScoreOScottish1k.ts
@@ -1,0 +1,91 @@
+import { Guid } from "guid-typescript";
+import { SingleRaceSoloScoreOResult } from "../CompetitionClass/SingleRaceSoloScoreOResult";
+import { ComputedCompetitionClass } from "./ComputedCompetitionClass";
+import { RenderStyles } from "../Styles/RenderStyles";
+import { PlaintextColumn } from "../Styles/PlaintextColumn";
+import { PlaintextTable } from "../Styles/PlaintextTable";
+
+export class Computed_Cascade_SingleSoloScoreOScottish1k extends ComputedCompetitionClass {
+
+    results: SingleRaceSoloScoreOResult[]
+
+    constructor(competitionClassId:Guid, name:string, r: SingleRaceSoloScoreOResult[]) {
+        super(competitionClassId, name, r);
+        this.results = r
+    }
+
+    render(style:RenderStyles): string {
+        switch (style) {
+            case RenderStyles.standard_txt: 
+                return this.render_txt();
+            case RenderStyles.standard_html: 
+                return this.render_html();
+            case RenderStyles.cascade_wordpresshtml:
+                return this.cascade_wordpresshtml();
+            default: 
+                return this.render_html();
+        }
+    }
+
+    render_txt(): string {
+        let doc = "";
+        doc += `${this.name}`
+        doc += "\r\n";
+
+        if (this.totalFinishers() === 0) {
+            doc += `(No participants for this class)\r\n\r\n`
+            return doc;
+        }
+
+        const PL = new PlaintextColumn(
+            "Pl",
+            SingleRaceSoloScoreOResult.getPlace,
+            this.results,
+            "start")
+
+        const NAME = new PlaintextColumn(
+            "Name",
+            SingleRaceSoloScoreOResult.getNameClub,
+            this.results)
+        
+        const RAW = new PlaintextColumn(
+            "Points",
+            SingleRaceSoloScoreOResult.getRawScore,
+            this.results,
+            "start")
+
+        const PEN = new PlaintextColumn(
+            "Penalty",
+            SingleRaceSoloScoreOResult.getPenalty,
+            this.results,
+            "start")
+
+        const SCORE = new PlaintextColumn(
+            "Score",
+            SingleRaceSoloScoreOResult.getFinalScore,
+            this.results,
+            "start")
+
+        const TIME = new PlaintextColumn(
+            "Time",
+            SingleRaceSoloScoreOResult.getTimeMMMSS,
+            this.results,
+            "start")
+
+        const PTS = new PlaintextColumn(
+            "Score",
+            SingleRaceSoloScoreOResult.getPoints,
+            this.results,
+            "start")
+
+        return doc += new PlaintextTable([PL,NAME,RAW,PEN,SCORE,TIME,PTS], this.results).tableString
+    }
+
+    render_html(): string {
+        return ""
+    }
+
+    cascade_wordpresshtml(): string {
+        return ""
+    }
+}

--- a/losttime.web/src/results2/ComputedCompetitionClass/Computed_Cascade_SingleSoloScoreOScottish1k.ts
+++ b/losttime.web/src/results2/ComputedCompetitionClass/Computed_Cascade_SingleSoloScoreOScottish1k.ts
@@ -4,6 +4,8 @@ import { ComputedCompetitionClass } from "./ComputedCompetitionClass";
 import { RenderStyles } from "../Styles/RenderStyles";
 import { PlaintextColumn } from "../Styles/PlaintextColumn";
 import { PlaintextTable } from "../Styles/PlaintextTable";
+import { HtmlColumn } from "../Styles/HtmlColumn";
+import { HtmlTable } from "../Styles/HtmlTable";
 
 export class Computed_Cascade_SingleSoloScoreOScottish1k extends ComputedCompetitionClass {
 
@@ -82,10 +84,122 @@ export class Computed_Cascade_SingleSoloScoreOScottish1k extends ComputedCompeti
     }
 
     render_html(): string {
-        return ""
+        let doc = document.createElement("div")
+        const h2 = document.createElement("h2")
+        h2.textContent = `${this.name}`
+        h2.setAttribute("id", `competition-class-${this.id.toString()}`)
+        doc.appendChild(h2);
+        
+        if (this.totalFinishers() === 0) {
+            const p = document.createElement("p")
+            p.textContent = "(No participants for this class)"
+            doc.appendChild(p)
+            return this.stringify_html(doc)
+        }
+
+        const PL = new HtmlColumn(
+            "Place", 
+            SingleRaceSoloScoreOResult.getPlace
+        )
+        const NAME = new HtmlColumn(
+            "Name",
+            SingleRaceSoloScoreOResult.getNameClub
+        )
+        const RAW = new HtmlColumn(
+            "Points",
+            SingleRaceSoloScoreOResult.getRawScore,
+            "text-right"
+        )
+        const PEN = new HtmlColumn(
+            "Penalty",
+            SingleRaceSoloScoreOResult.getPenalty,
+            "text-right"
+        )
+        const SCORE = new HtmlColumn(
+            "Score",
+            SingleRaceSoloScoreOResult.getFinalScore,
+            "text-right"
+        )
+        const TIME = new HtmlColumn(
+            "Time",
+            SingleRaceSoloScoreOResult.getTimeWithStatus,
+            "text-right"
+        )
+        const PTS = new HtmlColumn(
+            "Score",
+            SingleRaceSoloScoreOResult.getPoints,
+            "text-right"
+        )
+        const table = new HtmlTable([PL,NAME,RAW,PEN,SCORE,TIME,PTS],this,this.results).doc
+        doc.appendChild(table)
+        return this.stringify_html(doc)
     }
 
     cascade_wordpresshtml(): string {
-        return ""
+        let doc = document.createElement("div")
+        doc.setAttribute("class", "lg-mrg-bottom")
+        const h3 = document.createElement("h3")
+        h3.textContent = `${this.name}`
+        h3.setAttribute("id", `competition-class-${this.id.toString()}`)
+        doc.appendChild(h3);
+        
+        if (this.totalFinishers() === 0) {
+            const p = document.createElement("p")
+            p.textContent = "(No participants for this class)"
+            doc.appendChild(p)
+            return this.stringify_html(doc)
+        }
+
+        const PL = new HtmlColumn(
+            "Pos", 
+            SingleRaceSoloScoreOResult.getPlace
+        )
+        const NAME = new HtmlColumn(
+            "Name",
+            SingleRaceSoloScoreOResult.getName
+        )
+        const CLUB = new HtmlColumn(
+            "Club",
+            SingleRaceSoloScoreOResult.getClubCode
+        )
+        const RAW = new HtmlColumn(
+            "Points",
+            SingleRaceSoloScoreOResult.getRawScore,
+            "text-right"
+        )
+        const PEN = new HtmlColumn(
+            "Penalty",
+            SingleRaceSoloScoreOResult.getPenalty,
+            "text-right"
+        )
+        const SCORE = new HtmlColumn(
+            "Score",
+            SingleRaceSoloScoreOResult.getFinalScore,
+            "text-right"
+        )
+        const TIME = new HtmlColumn(
+            "Time",
+            SingleRaceSoloScoreOResult.getTimeMMMSS,
+            "text-right"
+        )
+        const PTS = new HtmlColumn(
+            "Score",
+            SingleRaceSoloScoreOResult.getPoints,
+            "text-right"
+        )
+        const table = new HtmlTable([PL,NAME,CLUB,RAW,PEN,SCORE,TIME,PTS],this,this.results).doc
+        doc.appendChild(table)
+
+        const menudiv = document.createElement("div")
+        const p = document.createElement("p")
+        p.setAttribute("class", "lg-mrg-bottom text-center");
+        const a = document.createElement("a")
+        a.setAttribute("href", "#lt-menu")
+        a.textContent = `Menu`
+        p.appendChild(a)
+        menudiv.appendChild(p)
+        doc.appendChild(menudiv)
+
+        return this.stringify_html(doc)
     }
 }

--- a/losttime.web/src/results2/ComputedCompetitionClass/Computed_Cascade_SingleTeamPointed.ts
+++ b/losttime.web/src/results2/ComputedCompetitionClass/Computed_Cascade_SingleTeamPointed.ts
@@ -1,6 +1,6 @@
 import { Guid } from "guid-typescript";
 import { ComputedCompetitionClass } from "./ComputedCompetitionClass";
-import { SingleRaceSoloPointedResult } from "../CompetitionClass/SingleRaceSoloPointedResult";
+import { SingleRaceSoloResult } from "../CompetitionClass/SingleRaceSoloResult";
 import { RenderStyles } from "../Styles/RenderStyles";
 import { PlaintextColumn } from "../Styles/PlaintextColumn";
 import { PlaintextTable } from "../Styles/PlaintextTable";
@@ -12,7 +12,7 @@ import { CodeCheckingStatus } from "../../results/scoremethods/IofStatusParser";
 export class Computed_Cascade_SingleTeamPointed extends ComputedCompetitionClass {
 
     results:SingleRaceTeamResult[]
-    mixedResults: (SingleRaceTeamResult|SingleRaceSoloPointedResult)[]
+    mixedResults: (SingleRaceTeamResult|SingleRaceSoloResult)[]
 
     constructor(competitionClassId:Guid, name:string, r: SingleRaceTeamResult[]) {
         super(competitionClassId, name, r);
@@ -20,8 +20,8 @@ export class Computed_Cascade_SingleTeamPointed extends ComputedCompetitionClass
         this.mixedResults = this.buildMixedResults()
     }
 
-    private buildMixedResults():(SingleRaceTeamResult|SingleRaceSoloPointedResult)[] {
-        let res:(SingleRaceTeamResult|SingleRaceSoloPointedResult)[] = []
+    private buildMixedResults():(SingleRaceTeamResult|SingleRaceSoloResult)[] {
+        let res:(SingleRaceTeamResult|SingleRaceSoloResult)[] = []
         this.results.forEach((team) => {
             res.push(team);
             team.soloResults.forEach((r) => {
@@ -31,7 +31,7 @@ export class Computed_Cascade_SingleTeamPointed extends ComputedCompetitionClass
         return res;
     }
 
-    private getTeamPlace = (r:SingleRaceTeamResult|SingleRaceSoloPointedResult):string => {
+    private getTeamPlace = (r:SingleRaceTeamResult|SingleRaceSoloResult):string => {
         if (r instanceof SingleRaceTeamResult) {
             return `${r.place}`
         } else {
@@ -39,25 +39,25 @@ export class Computed_Cascade_SingleTeamPointed extends ComputedCompetitionClass
         }
     }
 
-    private getTeamOrSoloNameArrowIndent = (r:SingleRaceTeamResult|SingleRaceSoloPointedResult):string => {
+    private getTeamOrSoloNameArrowIndent = (r:SingleRaceTeamResult|SingleRaceSoloResult):string => {
         if (r instanceof SingleRaceTeamResult) {
-            return `${r.teamName} (${r.club})`
+            return SingleRaceTeamResult.getTeamClub(r)
         } else {
-            return `->${r.name}`
+            return `->${SingleRaceSoloResult.getName(r)}`
         }
     }
 
-    private getPoints = (r:SingleRaceTeamResult|SingleRaceSoloPointedResult):string => `${r.points ?? ""}`
+    private getPoints = (r:SingleRaceTeamResult|SingleRaceSoloResult):string => `${r.points ?? ""}`
 
-    private getTeamOrSoloName = (r:SingleRaceTeamResult|SingleRaceSoloPointedResult):string => {
+    private getTeamOrSoloName = (r:SingleRaceTeamResult|SingleRaceSoloResult):string => {
         if (r instanceof SingleRaceTeamResult) {
-            return `${r.teamName} (${r.club})`
+            return SingleRaceTeamResult.getTeamClub(r)
         } else {
-            return `${r.name} (${r.club})`
+            return SingleRaceSoloResult.getNameClub(r)
         }
     }
 
-    private getTeamFinishStatsOrSoloTime = (r:SingleRaceTeamResult|SingleRaceSoloPointedResult):string => {
+    private getTeamFinishStatsOrSoloTime = (r:SingleRaceTeamResult|SingleRaceSoloResult):string => {
         if (r instanceof SingleRaceTeamResult) {
             const fin = r.soloResultsAll.filter((x)=>x.codeChecking===CodeCheckingStatus.FIN).length
             const pct = Math.round(fin*100/r.soloResultsAll.length)

--- a/losttime.web/src/results2/ComputedCompetitionClass/Computed_Ousa_SingleSoloAvgWinTime.ts
+++ b/losttime.web/src/results2/ComputedCompetitionClass/Computed_Ousa_SingleSoloAvgWinTime.ts
@@ -1,10 +1,10 @@
 import { Guid } from "guid-typescript";
 import { ComputedCompetitionClass } from "./ComputedCompetitionClass";
-import { SingleRaceSoloPointedResult } from "../CompetitionClass/SingleRaceSoloPointedResult";
+import { SingleRaceSoloResult } from "../CompetitionClass/SingleRaceSoloResult";
 import { RenderStyles } from "../Styles/RenderStyles";
 
 export class Computed_Ousa_SingleSoloAvgWinTime extends ComputedCompetitionClass {
-    constructor(competitionClassId:Guid, name:string, r: SingleRaceSoloPointedResult[]) {
+    constructor(competitionClassId:Guid, name:string, r: SingleRaceSoloResult[]) {
         super(competitionClassId, name, r);
     }
 
@@ -24,9 +24,9 @@ export class Computed_Ousa_SingleSoloAvgWinTime extends ComputedCompetitionClass
             return "";
         }
         let doc = "";
-        for (const el of this.results as SingleRaceSoloPointedResult[]) {
+        for (const el of this.results as SingleRaceSoloResult[]) {
             doc += `Place: ${el.place} `;
-            doc += `Name: ${el.name} (${el.club}) `;
+            doc += `Name: ${el.person.first + el.person.last} (${el.person.clubCode}) `;
             doc += `Time: ${this.timeWithStatusString(el)} `;
             doc += `Points: ${el.points}`;
             doc += "\r\n";

--- a/losttime.web/src/results2/ComputedCompetitionClass/Computed_Standard_ScoreO.ts
+++ b/losttime.web/src/results2/ComputedCompetitionClass/Computed_Standard_ScoreO.ts
@@ -4,6 +4,8 @@ import { ComputedCompetitionClass } from "./ComputedCompetitionClass";
 import { RenderStyles } from "../Styles/RenderStyles";
 import { PlaintextColumn } from "../Styles/PlaintextColumn";
 import { PlaintextTable } from "../Styles/PlaintextTable";
+import { HtmlColumn } from "../Styles/HtmlColumn";
+import { HtmlTable } from "../Styles/HtmlTable";
 
 export class Computed_Standard_ScoreO extends ComputedCompetitionClass {
 
@@ -76,10 +78,112 @@ export class Computed_Standard_ScoreO extends ComputedCompetitionClass {
     }
 
     render_html(): string {
-        return ""
+        let doc = document.createElement("div")
+        const h2 = document.createElement("h2")
+        h2.textContent = `${this.name}`
+        h2.setAttribute("id", `competition-class-${this.id.toString()}`)
+        doc.appendChild(h2);
+        
+        if (this.totalFinishers() === 0) {
+            const p = document.createElement("p")
+            p.textContent = "(No participants for this class)"
+            doc.appendChild(p)
+            return this.stringify_html(doc)
+        }
+
+        const PL = new HtmlColumn(
+            "Place", 
+            SingleRaceSoloScoreOResult.getPlace
+        )
+        const NAME = new HtmlColumn(
+            "Name",
+            SingleRaceSoloScoreOResult.getNameClub
+        )
+        const RAW = new HtmlColumn(
+            "Points",
+            SingleRaceSoloScoreOResult.getRawScore,
+            "text-right"
+        )
+        const PEN = new HtmlColumn(
+            "Penalty",
+            SingleRaceSoloScoreOResult.getPenalty,
+            "text-right"
+        )
+        const SCORE = new HtmlColumn(
+            "Score",
+            SingleRaceSoloScoreOResult.getFinalScore,
+            "text-right"
+        )
+        const TIME = new HtmlColumn(
+            "Time",
+            SingleRaceSoloScoreOResult.getTimeWithStatus,
+            "text-right"
+        )
+        const table = new HtmlTable([PL,NAME,RAW,PEN,SCORE,TIME],this,this.results).doc
+        doc.appendChild(table)
+        return this.stringify_html(doc)
     }
 
     cascade_wordpresshtml(): string {
-        return ""
+        let doc = document.createElement("div")
+        doc.setAttribute("class", "lg-mrg-bottom")
+        const h3 = document.createElement("h3")
+        h3.textContent = `${this.name}`
+        h3.setAttribute("id", `competition-class-${this.id.toString()}`)
+        doc.appendChild(h3);
+        
+        if (this.totalFinishers() === 0) {
+            const p = document.createElement("p")
+            p.textContent = "(No participants for this class)"
+            doc.appendChild(p)
+            return this.stringify_html(doc)
+        }
+
+        const PL = new HtmlColumn(
+            "Pos", 
+            SingleRaceSoloScoreOResult.getPlace
+        )
+        const NAME = new HtmlColumn(
+            "Name",
+            SingleRaceSoloScoreOResult.getName
+        )
+        const CLUB = new HtmlColumn(
+            "Club",
+            SingleRaceSoloScoreOResult.getClubCode
+        )
+        const RAW = new HtmlColumn(
+            "Points",
+            SingleRaceSoloScoreOResult.getRawScore,
+            "text-right"
+        )
+        const PEN = new HtmlColumn(
+            "Penalty",
+            SingleRaceSoloScoreOResult.getPenalty,
+            "text-right"
+        )
+        const SCORE = new HtmlColumn(
+            "Score",
+            SingleRaceSoloScoreOResult.getFinalScore,
+            "text-right"
+        )
+        const TIME = new HtmlColumn(
+            "Time",
+            SingleRaceSoloScoreOResult.getTimeMMMSS,
+            "text-right"
+        )
+        const table = new HtmlTable([PL,NAME,CLUB,RAW,PEN,SCORE,TIME],this,this.results).doc
+        doc.appendChild(table)
+
+        const menudiv = document.createElement("div")
+        const p = document.createElement("p")
+        p.setAttribute("class", "lg-mrg-bottom text-center");
+        const a = document.createElement("a")
+        a.setAttribute("href", "#lt-menu")
+        a.textContent = `Menu`
+        p.appendChild(a)
+        menudiv.appendChild(p)
+        doc.appendChild(menudiv)
+
+        return this.stringify_html(doc)
     }
 }

--- a/losttime.web/src/results2/ComputedCompetitionClass/Computed_Standard_ScoreO.ts
+++ b/losttime.web/src/results2/ComputedCompetitionClass/Computed_Standard_ScoreO.ts
@@ -1,0 +1,85 @@
+import { Guid } from "guid-typescript";
+import { SingleRaceSoloScoreOResult } from "../CompetitionClass/SingleRaceSoloScoreOResult";
+import { ComputedCompetitionClass } from "./ComputedCompetitionClass";
+import { RenderStyles } from "../Styles/RenderStyles";
+import { PlaintextColumn } from "../Styles/PlaintextColumn";
+import { PlaintextTable } from "../Styles/PlaintextTable";
+
+export class Computed_Standard_ScoreO extends ComputedCompetitionClass {
+
+    results: SingleRaceSoloScoreOResult[]
+
+    constructor(competitionClassId:Guid, name:string, r: SingleRaceSoloScoreOResult[]) {
+        super(competitionClassId, name, r);
+        this.results = r
+    }
+
+    render(style:RenderStyles): string {
+        switch (style) {
+            case RenderStyles.standard_txt: 
+                return this.render_txt();
+            case RenderStyles.standard_html: 
+                return this.render_html();
+            case RenderStyles.cascade_wordpresshtml:
+                return this.cascade_wordpresshtml();
+            default: 
+                return this.render_html();
+        }
+    }
+
+    render_txt(): string {
+        let doc = "";
+        doc += `${this.name}`
+        doc += "\r\n";
+
+        if (this.totalFinishers() === 0) {
+            doc += `(No participants for this class)\r\n\r\n`
+            return doc;
+        }
+
+        const PL = new PlaintextColumn(
+            "Pl",
+            SingleRaceSoloScoreOResult.getPlace,
+            this.results,
+            "start")
+
+        const NAME = new PlaintextColumn(
+            "Name",
+            SingleRaceSoloScoreOResult.getNameClub,
+            this.results)
+        
+        const RAW = new PlaintextColumn(
+            "Points",
+            SingleRaceSoloScoreOResult.getRawScore,
+            this.results,
+            "start")
+
+        const PEN = new PlaintextColumn(
+            "Penalty",
+            SingleRaceSoloScoreOResult.getPenalty,
+            this.results,
+            "start")
+
+        const SCORE = new PlaintextColumn(
+            "Score",
+            SingleRaceSoloScoreOResult.getFinalScore,
+            this.results,
+            "start")
+
+        const TIME = new PlaintextColumn(
+            "Time",
+            SingleRaceSoloScoreOResult.getTimeMMMSS,
+            this.results,
+            "start")
+
+        return doc += new PlaintextTable([PL,NAME,RAW,PEN,SCORE,TIME], this.results).tableString
+    }
+
+    render_html(): string {
+        return ""
+    }
+
+    cascade_wordpresshtml(): string {
+        return ""
+    }
+}

--- a/losttime.web/src/results2/ComputedCompetitionClass/Computed_Standard_Time.ts
+++ b/losttime.web/src/results2/ComputedCompetitionClass/Computed_Standard_Time.ts
@@ -1,4 +1,3 @@
-// import { Guid } from "guid-typescript";
 import { ComputedCompetitionClass } from "./ComputedCompetitionClass";
 import { SingleRaceSoloResult } from "../CompetitionClass/SingleRaceSoloResult";
 import { RenderStyles } from "../Styles/RenderStyles";
@@ -9,15 +8,6 @@ import { HtmlTable } from "../Styles/HtmlTable";
 
 
 export class Computed_Standard_Time extends ComputedCompetitionClass {
-    // constructor(competitionClassId:Guid, name:string, r: SingleRaceSoloResult[]) {
-    //     super(competitionClassId, name, r);
-    // }
-
-    private getPlace = (r:SingleRaceSoloResult):string => `${r.place ?? ""}`
-    private getNameClub = (r:SingleRaceSoloResult):string => `${r.name} (${r.club})`
-    private getName = (r:SingleRaceSoloResult):string => `${r.name}`
-    private getClub = (r:SingleRaceSoloResult):string => `${r.club}`
-    private getTime = (r:SingleRaceSoloResult):string => `${this.timeWithStatusString(r)}`
 
     render(style:RenderStyles): string {
         switch (style) {
@@ -44,18 +34,18 @@ export class Computed_Standard_Time extends ComputedCompetitionClass {
         
         const PL = new PlaintextColumn(
             "Pl",
-            this.getPlace,
+            SingleRaceSoloResult.getPlace,
             this.results,
             "start")
 
         const NAME = new PlaintextColumn(
             "Name",
-            this.getNameClub,
+            SingleRaceSoloResult.getNameClub,
             this.results)
         
         const TIME = new PlaintextColumn(
             "Time",
-            this.getTime,
+            SingleRaceSoloResult.getTimeWithStatus,
             this.results,
             "start")
         
@@ -78,15 +68,15 @@ export class Computed_Standard_Time extends ComputedCompetitionClass {
 
         const PL = new HtmlColumn(
             "Place", 
-            this.getPlace
+            SingleRaceSoloResult.getPlace
         )
         const NAME = new HtmlColumn(
             "Name",
-            this.getNameClub
+            SingleRaceSoloResult.getNameClub
         )
         const TIME = new HtmlColumn(
             "Time",
-            this.getTime,
+            SingleRaceSoloResult.getTimeWithStatus,
             "text-right"
         )
         const table = new HtmlTable([PL,NAME,TIME],this,this.results).doc
@@ -111,19 +101,19 @@ export class Computed_Standard_Time extends ComputedCompetitionClass {
 
         const PL = new HtmlColumn(
             "Pos", 
-            this.getPlace
+            SingleRaceSoloResult.getPlace
         )
         const NAME = new HtmlColumn(
             "Name",
-            this.getName
+            SingleRaceSoloResult.getName
         )
         const CLUB = new HtmlColumn(
             "Club",
-            this.getClub
+            SingleRaceSoloResult.getClubCode
         )
         const TIME = new HtmlColumn(
             "Time",
-            this.getTime,
+            SingleRaceSoloResult.getTimeWithStatus,
             "text-right"
         )
         const table = new HtmlTable([PL,NAME,CLUB,TIME],this,this.results).doc

--- a/losttime.web/src/results2/StandardRaceClassData.ts
+++ b/losttime.web/src/results2/StandardRaceClassData.ts
@@ -1,6 +1,4 @@
 import { Guid } from "guid-typescript";
-import { Class, ClassResult, Course, PersonResult } from "../shared/orienteeringtypes/IofResultXml";
-import { genericResult, genericScoreResult } from "../shared/orienteeringtypes/LostTimeCsv";
 import { LtCourse } from "../shared/orienteeringtypes/LtCourse";
 import { LtRaceClass } from "../shared/orienteeringtypes/LtRaceClass";
 import { LtResult } from "../shared/orienteeringtypes/LtResult";
@@ -29,30 +27,3 @@ export class StandardRaceClassData {
         this.course = course
     }
 }
-
-// export class StandardRaceClassData_XML extends StandardRaceClassData{
-//     xmlClass: Class;
-//     xmlCourse: Course;
-//     xmlPersonResults:PersonResult[];
-
-//     constructor(race: StandardRaceData, xmlClassResult: ClassResult) {
-//         super(race)
-//         this.xmlClass = xmlClassResult.Class;
-//         this.xmlCourse = xmlClassResult.Course;
-//         // Use [wrap].flat() to ensure there's an array.
-//         // without this, if only one PersonResult, it's just an object
-//         // and does not get filled because it's expecting an array.
-//         this.xmlPersonResults = [xmlClassResult.PersonResult].flat()
-//     }
-// }
-
-// export class StandardRaceClassData_CSV extends StandardRaceClassData{
-//     csvClass: string
-//     csvResults: genericResult[] | genericScoreResult[]
-
-//     constructor(race: StandardRaceData, className: string, data: genericResult[]|genericScoreResult[]) {
-//         super(race)
-//         this.csvClass = className
-//         this.csvResults = data
-//     }
-// }

--- a/losttime.web/src/results2/StandardRaceClassData.ts
+++ b/losttime.web/src/results2/StandardRaceClassData.ts
@@ -1,5 +1,10 @@
 import { Guid } from "guid-typescript";
 import { Class, ClassResult, Course, PersonResult } from "../shared/orienteeringtypes/IofResultXml";
+import { genericResult, genericScoreResult } from "../shared/orienteeringtypes/LostTimeCsv";
+import { LtCourse } from "../shared/orienteeringtypes/LtCourse";
+import { LtRaceClass } from "../shared/orienteeringtypes/LtRaceClass";
+import { LtResult } from "../shared/orienteeringtypes/LtResult";
+import { LtScoreOResult } from "../shared/orienteeringtypes/LtScoreOResult";
 
 interface StandardRaceData {
     id: Guid;
@@ -11,20 +16,43 @@ export class StandardRaceClassData {
     id: Guid;
     race_id: Guid;
     race_name: string;
-    xmlClass: Class;
-    xmlCourse: Course;
-    xmlPersonResults:PersonResult[];
+    course?: LtCourse;
+    class: LtRaceClass;
+    results: LtResult[]|LtScoreOResult[];
 
-    constructor(race: StandardRaceData, xmlClassResult: ClassResult) {
+    constructor(race: StandardRaceData, raceClass: LtRaceClass, results: LtResult[], course?: LtCourse ) {
         this.id = Guid.create();
         this.race_id = race.id;
         this.race_name = race.name
-        this.xmlClass = xmlClassResult.Class;
-        this.xmlCourse = xmlClassResult.Course;
-        // Use [wrap].flat() to ensure there's an array.
-        // without this, if only one PersonResult, it's just an object
-        // and does not get filled because it's expecting an array.
-        this.xmlPersonResults = [xmlClassResult.PersonResult].flat()
+        this.class = raceClass
+        this.results = results
+        this.course = course
     }
-
 }
+
+// export class StandardRaceClassData_XML extends StandardRaceClassData{
+//     xmlClass: Class;
+//     xmlCourse: Course;
+//     xmlPersonResults:PersonResult[];
+
+//     constructor(race: StandardRaceData, xmlClassResult: ClassResult) {
+//         super(race)
+//         this.xmlClass = xmlClassResult.Class;
+//         this.xmlCourse = xmlClassResult.Course;
+//         // Use [wrap].flat() to ensure there's an array.
+//         // without this, if only one PersonResult, it's just an object
+//         // and does not get filled because it's expecting an array.
+//         this.xmlPersonResults = [xmlClassResult.PersonResult].flat()
+//     }
+// }
+
+// export class StandardRaceClassData_CSV extends StandardRaceClassData{
+//     csvClass: string
+//     csvResults: genericResult[] | genericScoreResult[]
+
+//     constructor(race: StandardRaceData, className: string, data: genericResult[]|genericScoreResult[]) {
+//         super(race)
+//         this.csvClass = className
+//         this.csvResults = data
+//     }
+// }

--- a/losttime.web/src/shared/orienteeringtypes/IofResultXml.ts
+++ b/losttime.web/src/shared/orienteeringtypes/IofResultXml.ts
@@ -1,4 +1,3 @@
-import { iofStatusParser } from "../../results/scoremethods/IofStatusParser";
 import { LtPerson } from "./LtPerson";
 import { LtResult } from "./LtResult";
 

--- a/losttime.web/src/shared/orienteeringtypes/IofResultXml.ts
+++ b/losttime.web/src/shared/orienteeringtypes/IofResultXml.ts
@@ -1,3 +1,7 @@
+import { iofStatusParser } from "../../results/scoremethods/IofStatusParser";
+import { LtPerson } from "./LtPerson";
+import { LtResult } from "./LtResult";
+
 export type ResultList = {
     ClassResult: ClassResult[];
     Event: Event;
@@ -21,11 +25,11 @@ export type Class = {
 }
 
 export type Course = {
-    Id: Number;
+    Id: number;
     Name: string;
-    Length?: Number;
-    NumberOfControls?: Number;
-    Climb?: Number;
+    Length?: number;
+    NumberOfControls?: number;
+    Climb?: number;
 }
 
 export type PersonResult = {
@@ -64,4 +68,19 @@ export type Result = {
 export type SplitTime = {
     ControlCode: number;
     Time?: number;
+}
+
+export function IofXml3ToLtResult(r:PersonResult):LtResult {
+    const person = new LtPerson(r.Person.Name.Given??"", r.Person.Name.Family??"",r.Organisation.ShortName, r.Organisation.Name)
+
+    return new LtResult({
+        person: person,
+        bib: r.Result.BibNumber?.toString(),
+        card: r.Result.ControlCard?.toString(),
+        start: r.Result.StartTime?? undefined,
+        finish: r.Result.FinishTime?? undefined,
+        time: r.Result.Time,
+        status: r.Result.Status,
+        position: r.Result.Position?? undefined
+    })
 }

--- a/losttime.web/src/shared/orienteeringtypes/LostTimeCsv.ts
+++ b/losttime.web/src/shared/orienteeringtypes/LostTimeCsv.ts
@@ -1,0 +1,40 @@
+
+
+
+export type genericResult = {
+    name: {
+        first?: string
+        last?: string
+    }
+    club: {
+        name: string
+        shortName?: string
+    }
+    ControlCard?: number;
+    StartTime?: string;
+    FinishTime?: string;
+    Time: number;
+    Status?: string;
+    Position?: number;
+}
+
+export type genericScoreResult = {
+    name: {
+        first?: string
+        last?: string
+    }
+    club: {
+        name: string
+        shortName?: string
+    }
+    ControlCard?: number;
+    StartTime?: string;
+    FinishTime?: string;
+    Time: number;
+    Status?: string;
+    Position?: number;
+    RawScore: number,
+    Penalty: number,
+    Bonus: number,
+    NetScore: number
+}

--- a/losttime.web/src/shared/orienteeringtypes/LtCourse.ts
+++ b/losttime.web/src/shared/orienteeringtypes/LtCourse.ts
@@ -1,0 +1,13 @@
+export class LtCourse {
+    name: string
+    controls?: number
+    distance_km?: number
+    climb?: number
+
+    constructor(name: string, controls?: number, distance?: number,  climb?: number) {
+        this.name = name
+        this.controls = controls
+        this.distance_km = distance
+        this.climb = climb
+    }
+}

--- a/losttime.web/src/shared/orienteeringtypes/LtPerson.ts
+++ b/losttime.web/src/shared/orienteeringtypes/LtPerson.ts
@@ -1,0 +1,21 @@
+import { getClubNameString } from "../../results/outputstyles/stylehelpers"
+
+export class LtPerson {
+    first: string
+    last: string
+    club: string
+    clubCode: string
+
+    constructor(first: string, last: string, clubCode: string, club?: string) {
+        this.first = first
+        this.last = last
+        this.clubCode = clubCode
+        if (club === undefined) {
+            this.club = getClubNameString(clubCode) ?? "None"
+        } else if (club === clubCode) {
+            this.club = getClubNameString(clubCode) ?? club
+        } else {
+            this.club = club
+        }
+    }
+}

--- a/losttime.web/src/shared/orienteeringtypes/LtRaceClass.ts
+++ b/losttime.web/src/shared/orienteeringtypes/LtRaceClass.ts
@@ -1,0 +1,9 @@
+export class LtRaceClass {
+    name: string
+    code: string
+
+    constructor(name:string, code:string) {
+        this.name = name
+        this.code = code
+    }
+}

--- a/losttime.web/src/shared/orienteeringtypes/LtResult.ts
+++ b/losttime.web/src/shared/orienteeringtypes/LtResult.ts
@@ -1,0 +1,39 @@
+import { CodeCheckingStatus, CompetitiveStatus, iofStatusParser } from "../../results/scoremethods/IofStatusParser"
+import { LtPerson } from "./LtPerson"
+
+interface LtResultParams {
+    person: LtPerson
+    bib?: string
+    card?: string
+    start?: string
+    finish?: string
+    time: number
+    status: string
+    position?: number
+}
+
+export class LtResult {
+    person: LtPerson
+    bib?: string
+    card?: string
+    start?: string
+    finish?: string
+    time: number
+    competeStatus: CompetitiveStatus
+    codeCheckStatus: CodeCheckingStatus
+    position?: number
+
+    constructor(params: LtResultParams)
+     {
+        this.person = params.person
+        this.bib = params.bib
+        this.card = params.card
+        this.start = params.start
+        this.finish = params.finish
+        this.time = params.time
+        this.competeStatus = iofStatusParser(params.status).CompetitiveStatus
+        this.codeCheckStatus = iofStatusParser(params.status).CodeCheckingStatus
+        this.position = params.position
+
+    }
+}

--- a/losttime.web/src/shared/orienteeringtypes/LtScoreOResult.ts
+++ b/losttime.web/src/shared/orienteeringtypes/LtScoreOResult.ts
@@ -1,0 +1,43 @@
+import { LtPerson } from "./LtPerson"
+import { LtResult } from "./LtResult"
+
+interface LtScoreOResultParams {
+    person: LtPerson
+    bib?: string
+    card?: string
+    start?: string
+    finish?: string
+    time: number
+    status: string
+    position?: number
+    scoreRaw: number;
+    penalty?: number; // always positive
+    bonus?: number;
+    score?: number // pointsRaw - penalty + bonus = score
+
+}
+
+export class LtScoreOResult extends LtResult {
+    scoreRaw: number;
+    penalty: number; // always positive
+    bonus: number;
+    score: number // pointsRaw - penalty + bonus = score
+
+    constructor(params: LtScoreOResultParams)
+     {
+        super(params)
+        this.scoreRaw = params.scoreRaw
+        this.penalty = params.penalty? Math.abs(params.penalty) : 0
+        this.bonus = params.bonus? Math.abs(params.bonus) : 0
+        if (params.score) {
+            const calcScore:number = params.scoreRaw - this.penalty + this.bonus
+            if (params.score != calcScore) {
+                console.log(`ISSUE! ${params.score} != ${params.scoreRaw}-${this.penalty}+${this.bonus} = ${calcScore}`)
+                Error("Math is wrong somewhere!")
+            }
+            this.score = params.score
+        } else {
+            this.score = params.scoreRaw - this.penalty + this.bonus
+        }
+    }
+}

--- a/losttime.web/src/shared/orienteeringtypes/OESco0012.ts
+++ b/losttime.web/src/shared/orienteeringtypes/OESco0012.ts
@@ -1,0 +1,122 @@
+// 0OESco0012
+// Stno
+// XStno
+// Chipno
+// Database Id
+// Surname
+// First name"
+// YB
+// S
+// Block
+// nc
+// Start
+// Finish
+// Time"
+// Classifier"
+// Credit -"
+// Penalty +"
+// Comment"
+// Club no."
+// Cl.name"
+// City"
+// Nat"
+// Location"
+// Region"
+// Cl. no."
+// Short"
+// Long"
+// Entry cl. No"
+// Entry class (short)"
+// Entry class (long)"
+// Rank"
+// Ranking points"
+// Num1"
+// Num2"
+// Num3"
+// Text1"
+// Text2"
+// Text3"
+// Addr. surname"
+// Addr. first name"
+// Street"
+// Line2"
+// Zip"
+// Addr. city"
+// Phone"
+// Mobile"
+// Fax"
+// EMail"
+// Rented"
+// Start fee"
+// Paid"
+// Team"
+// Course no."
+// Course"
+// Course controls"
+// Max. points"
+// Time limit"
+// Place"
+// Score Result"
+// Points"
+// Score Penalty"
+// Extra points"
+// Comment (Xtra)"
+
+import { LtPerson } from "./LtPerson"
+import { LtScoreOResult } from "./LtScoreOResult"
+import { TimeStringToSeconds } from "./timeHelpers"
+
+
+export type OESco0012 = {
+    // possibly everything is a string??
+    Chipno: string
+    Surname: string
+    "First name": string
+    YB:number
+    S: "M" | "F"
+    nc: 0 | "X"
+    Start: string
+    Finish: string
+    Time: string
+    City: string // Club abbreviation short
+    Region: string // Club full name
+    Short: string // Class code
+    Long: string // Class name
+    Rented: 0 | "X"
+    "Course no.": string
+    Course: string
+    "Course controls": number
+    "Max. points": number
+    "Time limit": string
+    "Place": number | "nc"
+    "Score Result": number
+    Points: number
+    "Score Penalty": number
+    "Extra points": number
+}
+
+export function OEScoCsvToLtScoreOResult(r:OESco0012):LtScoreOResult {
+    const person = new LtPerson(r["First name"], r.Surname, r.City, r.Region)
+    let timeInSeconds = TimeStringToSeconds(r.Time)
+    
+    if (Number.isNaN(timeInSeconds)) {
+        if (r.Start && r.Finish) {
+            timeInSeconds = TimeStringToSeconds(r.Finish) - TimeStringToSeconds(r.Start)
+        }
+    }
+    // TODO timeInSeconds might still be NaN
+
+    return new LtScoreOResult({
+        person: person,
+        card: r.Chipno,
+        start: r.Start,
+        finish: r.Finish,
+        time: timeInSeconds,
+        status: r.nc === "X" ? "NotCompeting" : "OK",
+        position: r.Place === "nc" ? undefined : r.Place,
+        scoreRaw: r.Points,
+        penalty: r["Score Penalty"],
+        bonus: r["Extra points"],
+        score: r["Score Result"]
+    })
+}

--- a/losttime.web/src/shared/orienteeringtypes/timeHelpers.ts
+++ b/losttime.web/src/shared/orienteeringtypes/timeHelpers.ts
@@ -1,0 +1,22 @@
+
+export function TimeStringToSeconds(time:string):number {
+    const HHMMSS = /\d+:\d{2}:\d{2}(\.\d*)?/
+    const MMMSS = /\d+:\d{2}(\.\d*)?/
+
+    if (HHMMSS.test(time)) { return HHMMSStoSeconds(time)}
+    if (MMMSS.test(time)) { return MMMSStoSeconds(time)}
+
+    return NaN
+}
+
+function HHMMSStoSeconds(HHMMSS:string):number {
+    const [hours, minutes, seconds] = HHMMSS.split(":",3)
+    const timeInSeconds = parseInt(hours)*60*60 + parseInt(minutes)*60 + parseInt(seconds)
+    return timeInSeconds
+}
+
+function MMMSStoSeconds(MMMSS:string):number {
+    const [minutes, seconds] = MMMSS.split(":",2)
+    const timeInSeconds = parseInt(minutes)*60 + parseInt(seconds)
+    return timeInSeconds
+}


### PR DESCRIPTION
Refactor results file upload to support xml or csv.
xml info no longer piped through to competition classes - uses new LtResult object where needed. This is extended to support ScoreO as well.
Baseline is there to support more generic csv upload, but this change is scoped to just the OESco0012 file