### PR TITLE
start times replace club in registration pdfs

### DIFF
--- a/losttime.web/src/entries/EntryFileParser.ts
+++ b/losttime.web/src/entries/EntryFileParser.ts
@@ -20,6 +20,7 @@ export class LtEntry {
     Club!: string;
     Course!: string;
     ClassId!: string;
+    StartTime!: string | null;
     NonCompetitive!: true | false;
     Sex!: "F" | "M";
     Phone!: string;
@@ -71,8 +72,9 @@ export class LtEntry {
         this.Course= '';
         this.ClassId= entry.Class;
         this.NonCompetitive= false;
-        this.Sex= entry.Sex
-        this.Phone= entry.Phone
+        this.Sex= entry.Sex;
+        this.Phone= entry.Phone;
+        this.StartTime = entry.StartTime;
         this.EmergencyPhone= entry.EmergencyPhone;
         this.CarLicense= entry.CarLicense
         this.Newcomer= (entry.Newcomer.toUpperCase() === 'TRUE') ? true:false;

--- a/losttime.web/src/shared/orienteeringtypes/CascadeRegistration.ts
+++ b/losttime.web/src/shared/orienteeringtypes/CascadeRegistration.ts
@@ -9,6 +9,7 @@ export class CascadeRegistrationCsv {
     Sex!: "F" | "M";
     EPunch!: string;
     Rental!: string;
+    StartTime!: string | null;
     Phone!: string;
     EmergencyPhone!: string;
     CarLicense!: string;


### PR DESCRIPTION
COC registration files now include start times. Pull these through into the registration PDFs.
WIOL doesn't use these, WES could but doesn't, Ultimate does (usually?), CYA doesn't have start times. So this is probably questionable functionality and may need more testing before adding, so leaving this as a draft for now to get back to other items